### PR TITLE
Simplify UI and remove preview asset

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -409,38 +409,37 @@ app.get('/', (req, res) => {
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh; color: #333;
+            background: #f5f5f6;
+            min-height: 100vh;
+            color: #333;
         }
-        .container { max-width: 1200px; margin: 0 auto; padding: 20px; }
-        .header { text-align: center; color: white; margin-bottom: 30px; }
-        .header h1 { font-size: 2.5rem; margin-bottom: 10px; text-shadow: 0 2px 4px rgba(0,0,0,0.3); }
-        .header p { font-size: 1.1rem; opacity: 0.9; }
+        .container { max-width: 900px; margin: 0 auto; padding: 20px; }
+        .header { text-align: center; color: #333; margin-bottom: 30px; }
+        .header h1 { font-size: 2rem; margin-bottom: 5px; }
+        .header p { font-size: 1rem; opacity: 0.8; }
         .version { font-size: 0.9rem; opacity: 0.8; margin-top: 5px; }
         .card {
-            background: white; border-radius: 15px; box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-            padding: 25px; margin-bottom: 20px; transition: transform 0.3s ease;
+            background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+            padding: 20px; margin-bottom: 20px;
         }
-        .card:hover { transform: translateY(-5px); }
         .tabs {
-            display: flex; background: #f8f9fa; border-radius: 10px; padding: 5px;
-            margin-bottom: 25px; overflow-x: auto;
+            display: flex; border-bottom: 1px solid #e5e7eb; margin-bottom: 20px; overflow-x: auto;
         }
         .tab {
-            flex: 1; padding: 12px 20px; text-align: center; border-radius: 8px;
-            cursor: pointer; transition: all 0.3s ease; white-space: nowrap; font-weight: 500;
+            padding: 10px 15px; margin-right: 15px; cursor: pointer; border-bottom: 3px solid transparent;
+            color: #555; white-space: nowrap; transition: border-color 0.2s ease, color 0.2s ease;
         }
-        .tab:hover { background: #e9ecef; }
-        .tab.active { background: #007bff; color: white; box-shadow: 0 2px 8px rgba(0,123,255,0.3); }
+        .tab:hover { color: #000; }
+        .tab.active { border-color: #3b82f6; color: #3b82f6; }
         .tab-content { display: none; }
         .tab-content.active { display: block; animation: fadeIn 0.3s ease; }
         @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
         .device-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 20px; margin-bottom: 20px; }
         .device {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white;
-            padding: 20px; border-radius: 12px; box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+            background: #fff; border-left: 4px solid #3b82f6;
+            padding: 15px; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
         }
-        .device.offline { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); }
+        .device.offline { border-color: #ef4444; }
         .device h3 { font-size: 1.2rem; margin-bottom: 15px; display: flex; align-items: center; gap: 10px; }
         .device-status { display: flex; justify-content: space-between; margin-bottom: 10px; }
         .status-indicator {
@@ -454,36 +453,35 @@ app.get('/', (req, res) => {
             width: 100%; padding: 12px 15px; border: 2px solid #e9ecef; border-radius: 8px;
             font-size: 14px; transition: border-color 0.3s ease;
         }
-        .form-control:focus { outline: none; border-color: #007bff; box-shadow: 0 0 0 3px rgba(0,123,255,0.1); }
+        .form-control:focus { outline: none; border-color: #3b82f6; box-shadow: 0 0 0 3px rgba(59,130,246,0.2); }
         .btn {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; border: none;
-            padding: 12px 25px; border-radius: 8px; cursor: pointer; font-size: 14px; font-weight: 600;
-            transition: all 0.3s ease; text-decoration: none; display: inline-flex; align-items: center; gap: 8px;
+            background: #3b82f6; color: #fff; border: none;
+            padding: 10px 20px; border-radius: 5px; cursor: pointer; font-size: 14px; font-weight: 600;
+            transition: background 0.2s ease; text-decoration: none; display: inline-flex; align-items: center; gap: 8px;
         }
-        .btn:hover { transform: translateY(-2px); box-shadow: 0 5px 15px rgba(0,0,0,0.2); }
-        .btn-success { background: linear-gradient(135deg, #4ade80 0%, #22c55e 100%); }
-        .btn-danger { background: linear-gradient(135deg, #f87171 0%, #ef4444 100%); }
-        .btn-secondary { background: linear-gradient(135deg, #64748b 0%, #475569 100%); }
+        .btn:hover { background: #2563eb; }
+        .btn-success { background: #22c55e; }
+        .btn-danger { background: #ef4444; }
+        .btn-secondary { background: #6b7280; }
         .logs {
-            background: #1a1a1a; color: #4ade80; font-family: 'Courier New', monospace;
-            padding: 20px; border-radius: 10px; height: 400px; overflow-y: auto; border: 2px solid #333;
+            background: #f9fafb; color: #111827; font-family: 'Courier New', monospace;
+            padding: 20px; border-radius: 6px; height: 400px; overflow-y: auto; border: 1px solid #e5e7eb;
         }
         .log-entry { margin-bottom: 5px; padding: 2px 0; }
         .log-error { color: #ef4444; } .log-warn { color: #f59e0b; } .log-info { color: #4ade80; }
         .upload-area {
-            border: 2px dashed #007bff; border-radius: 10px; padding: 40px; text-align: center;
-            background: #f8f9ff; transition: all 0.3s ease; cursor: pointer;
+            border: 2px dashed #3b82f6; border-radius: 8px; padding: 40px; text-align: center;
+            background: #f9fafb; transition: background 0.2s ease, border-color 0.2s ease; cursor: pointer;
         }
-        .upload-area:hover { border-color: #0056b3; background: #e7f3ff; }
-        .upload-area.dragover { border-color: #0056b3; background: #e7f3ff; transform: scale(1.02); }
-        .upload-icon { font-size: 3rem; color: #007bff; margin-bottom: 15px; }
+        .upload-area:hover { border-color: #2563eb; background: #eff6ff; }
+        .upload-area.dragover { border-color: #2563eb; background: #eff6ff; }
+        .upload-icon { font-size: 3rem; color: #3b82f6; margin-bottom: 15px; }
         .current-display {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white;
-            padding: 20px; border-radius: 12px; margin-bottom: 20px;
+            background: #fff; border: 1px solid #e5e7eb; padding: 20px; border-radius: 8px; margin-bottom: 20px;
         }
         .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 15px; margin-bottom: 20px; }
-        .stat-card { background: white; padding: 20px; border-radius: 10px; text-align: center; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
-        .stat-value { font-size: 2rem; font-weight: bold; color: #007bff; margin-bottom: 5px; }
+        .stat-card { background: #fff; padding: 20px; border-radius: 6px; text-align: center; border: 1px solid #e5e7eb; }
+        .stat-value { font-size: 2rem; font-weight: bold; color: #3b82f6; margin-bottom: 5px; }
         .stat-label { color: #666; font-size: 0.9rem; }
         @media (max-width: 768px) {
             .container { padding: 10px; } .header h1 { font-size: 2rem; }

--- a/server/web-interface.js
+++ b/server/web-interface.js
@@ -16,76 +16,68 @@ app.get("/", (req, res) => {
         }
         
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            background: #fafafa;
             min-height: 100vh;
             color: #333;
+            line-height: 1.5;
         }
-        
+
         .container {
-            max-width: 1200px;
+            max-width: 800px;
             margin: 0 auto;
             padding: 20px;
         }
-        
+
         .header {
             text-align: center;
-            color: white;
+            color: #333;
             margin-bottom: 30px;
         }
-        
+
         .header h1 {
-            font-size: 2.5rem;
-            margin-bottom: 10px;
-            text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+            font-size: 2rem;
+            margin-bottom: 5px;
         }
-        
+
         .header p {
-            font-size: 1.1rem;
-            opacity: 0.9;
+            font-size: 1rem;
+            opacity: 0.8;
         }
         
         .card {
-            background: white;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-            padding: 25px;
+            background: #fff;
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+            padding: 20px;
             margin-bottom: 20px;
-            transition: transform 0.3s ease;
-        }
-        
-        .card:hover {
-            transform: translateY(-5px);
         }
         
         .tabs {
             display: flex;
-            background: #f8f9fa;
-            border-radius: 10px;
-            padding: 5px;
-            margin-bottom: 25px;
+            border-bottom: 1px solid #e5e7eb;
+            margin-bottom: 20px;
             overflow-x: auto;
         }
-        
+
         .tab {
-            flex: 1;
-            padding: 12px 20px;
-            text-align: center;
-            border-radius: 8px;
+            padding: 10px 15px;
+            margin-right: 15px;
             cursor: pointer;
-            transition: all 0.3s ease;
+            border-bottom: 3px solid transparent;
+            color: #555;
             white-space: nowrap;
-            font-weight: 500;
+            transition: border-color 0.2s ease, color 0.2s ease;
         }
-        
+
         .tab:hover {
-            background: #e9ecef;
+            color: #000;
         }
-        
+
         .tab.active {
-            background: #007bff;
-            color: white;
-            box-shadow: 0 2px 8px rgba(0,123,255,0.3);
+            border-color: #3b82f6;
+            color: #3b82f6;
         }
         
         .tab-content {
@@ -110,15 +102,15 @@ app.get("/", (req, res) => {
         }
         
         .device {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            padding: 20px;
-            border-radius: 12px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+            background: #fff;
+            border-left: 4px solid #3b82f6;
+            padding: 15px;
+            border-radius: 6px;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.05);
         }
-        
+
         .device.offline {
-            background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+            border-color: #ef4444;
         }
         
         .device h3 {
@@ -174,52 +166,51 @@ app.get("/", (req, res) => {
         
         .form-control:focus {
             outline: none;
-            border-color: #007bff;
-            box-shadow: 0 0 0 3px rgba(0,123,255,0.1);
+            border-color: #3b82f6;
+            box-shadow: 0 0 0 3px rgba(59,130,246,0.2);
         }
         
         .btn {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
+            background: #3b82f6;
+            color: #fff;
             border: none;
-            padding: 12px 25px;
-            border-radius: 8px;
+            padding: 10px 20px;
+            border-radius: 5px;
             cursor: pointer;
             font-size: 14px;
             font-weight: 600;
-            transition: all 0.3s ease;
+            transition: background 0.2s ease;
             text-decoration: none;
             display: inline-flex;
             align-items: center;
             gap: 8px;
         }
-        
+
         .btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+            background: #2563eb;
         }
-        
+
         .btn-success {
-            background: linear-gradient(135deg, #4ade80 0%, #22c55e 100%);
+            background: #22c55e;
         }
-        
+
         .btn-danger {
-            background: linear-gradient(135deg, #f87171 0%, #ef4444 100%);
+            background: #ef4444;
         }
-        
+
         .btn-secondary {
-            background: linear-gradient(135deg, #64748b 0%, #475569 100%);
+            background: #6b7280;
         }
         
         .logs {
-            background: #1a1a1a;
-            color: #4ade80;
+            background: #f9fafb;
+            color: #111827;
             font-family: 'Courier New', monospace;
             padding: 20px;
-            border-radius: 10px;
+            border-radius: 6px;
             height: 400px;
             overflow-y: auto;
-            border: 2px solid #333;
+            border: 1px solid #e5e7eb;
         }
         
         .log-entry {
@@ -232,37 +223,36 @@ app.get("/", (req, res) => {
         .log-info { color: #4ade80; }
         
         .upload-area {
-            border: 2px dashed #007bff;
-            border-radius: 10px;
+            border: 2px dashed #3b82f6;
+            border-radius: 8px;
             padding: 40px;
             text-align: center;
-            background: #f8f9ff;
-            transition: all 0.3s ease;
+            background: #f9fafb;
+            transition: background 0.2s ease, border-color 0.2s ease;
             cursor: pointer;
         }
-        
+
         .upload-area:hover {
-            border-color: #0056b3;
-            background: #e7f3ff;
+            border-color: #2563eb;
+            background: #eff6ff;
         }
-        
+
         .upload-area.dragover {
-            border-color: #0056b3;
-            background: #e7f3ff;
-            transform: scale(1.02);
+            border-color: #2563eb;
+            background: #eff6ff;
         }
-        
+
         .upload-icon {
             font-size: 3rem;
-            color: #007bff;
+            color: #3b82f6;
             margin-bottom: 15px;
         }
         
         .current-display {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
+            background: #fff;
+            border: 1px solid #e5e7eb;
             padding: 20px;
-            border-radius: 12px;
+            border-radius: 8px;
             margin-bottom: 20px;
         }
         
@@ -274,17 +264,17 @@ app.get("/", (req, res) => {
         }
         
         .stat-card {
-            background: white;
+            background: #fff;
             padding: 20px;
-            border-radius: 10px;
+            border-radius: 6px;
             text-align: center;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            border: 1px solid #e5e7eb;
         }
         
         .stat-value {
             font-size: 2rem;
             font-weight: bold;
-            color: #007bff;
+            color: #3b82f6;
             margin-bottom: 5px;
         }
         


### PR DESCRIPTION
## Summary
- lighten fonts and colors for a cleaner design
- reduce card shadows and container width
- remove preview screenshot from repo

## Testing
- `npm install`
- `node -c server/server.js`
- `wkhtmltoimage --quality 90 http://localhost:3000 preview.png`

![Preview](attachment:/tmp/preview.png)


------
https://chatgpt.com/codex/tasks/task_b_6888d93ae1b0832bac2adf39b27f2db0