### PR TITLE
Add build metadata to server image

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   glance-server:
-    image: chaerem/glance-server:latest
+    image: chaerem/glance-server:${IMAGE_VERSION:-latest}
     container_name: glance-server
     ports:
       - "3000:3000"
@@ -11,7 +11,8 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
-      - IMAGE_VERSION=latest
+      - IMAGE_VERSION=${IMAGE_VERSION:-latest}
+      - BUILD_DATE=${BUILD_DATE:-unknown}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,11 @@ version: '3.8'
 
 services:
   glance-server:
-    build: ./server
+    build:
+      context: ./server
+      args:
+        IMAGE_VERSION: ${IMAGE_VERSION:-local}
+        BUILD_DATE: ${BUILD_DATE:-unknown}
     container_name: glance-server
     ports:
       - "3000:3000"
@@ -11,7 +15,8 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
-      - IMAGE_VERSION=local
+      - IMAGE_VERSION=${IMAGE_VERSION:-local}
+      - BUILD_DATE=${BUILD_DATE:-unknown}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/health"]

--- a/scripts/build-and-push.sh
+++ b/scripts/build-and-push.sh
@@ -34,12 +34,18 @@ docker buildx use glance-builder
 
 echo "🔨 Building multi-architecture image..."
 
+GIT_COMMIT=$(git rev-parse --short HEAD)
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
 # Build and push for multiple architectures
 docker buildx build \
     --platform linux/amd64,linux/arm64,linux/arm/v7 \
     --file server/Dockerfile \
     --context server \
+    --build-arg IMAGE_VERSION="$GIT_COMMIT" \
+    --build-arg BUILD_DATE="$BUILD_DATE" \
     --tag "${FULL_IMAGE_NAME}:${VERSION}" \
+    --tag "${FULL_IMAGE_NAME}:${GIT_COMMIT}" \
     --tag "${FULL_IMAGE_NAME}:${LATEST_TAG}" \
     --push \
     .

--- a/scripts/local-build.sh
+++ b/scripts/local-build.sh
@@ -11,14 +11,18 @@ echo "🔨 Building Glance Server locally..."
 cd "$(dirname "$0")/.."
 
 # Build for local architecture only
+COMMIT_SHA=$(git rev-parse --short HEAD)
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 docker build \
     --file server/Dockerfile \
-    --tag glance-server:local \
+    --build-arg IMAGE_VERSION="$COMMIT_SHA" \
+    --build-arg BUILD_DATE="$BUILD_DATE" \
+    --tag glance-server:$COMMIT_SHA \
     server/
 
 echo "✅ Local build complete!"
 echo ""
 echo "🧪 To test locally:"
-echo "   docker run -p 3000:3000 -v \$(pwd)/data:/app/data glance-server:local"
+echo "   docker run -p 3000:3000 -v \$(pwd)/data:/app/data glance-server:$COMMIT_SHA"
 echo ""
 echo "🌐 Then visit: http://localhost:3000"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,6 +6,14 @@ LABEL org.opencontainers.image.title="Glance Server" \
       org.opencontainers.image.version="1.0.0" \
       org.opencontainers.image.licenses="MIT"
 
+# Build metadata
+ARG IMAGE_VERSION=local
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.revision="$IMAGE_VERSION" \
+      org.opencontainers.image.created="$BUILD_DATE"
+ENV IMAGE_VERSION=$IMAGE_VERSION
+ENV BUILD_DATE=$BUILD_DATE
+
 WORKDIR /app
 
 # Install dumb-init for proper signal handling

--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,7 @@ const sharp = require('sharp');
 const app = express();
 const PORT = process.env.PORT || 3000;
 const IMAGE_VERSION = process.env.IMAGE_VERSION || 'local';
+const BUILD_DATE = process.env.BUILD_DATE || 'unknown';
 const DATA_DIR = path.join(__dirname, 'data');
 const UPLOAD_DIR = path.join(__dirname, 'uploads');
 
@@ -495,7 +496,7 @@ app.get('/', (req, res) => {
         <div class="header">
             <h1><i class="fas fa-display"></i> Glance E-Ink Display Server</h1>
             <p>Manage your autonomous e-paper displays with ease</p>
-            <p class="version">Docker Image Version: ${IMAGE_VERSION}</p>
+            <p class="version">Docker Image: ${IMAGE_VERSION} (built ${BUILD_DATE})</p>
         </div>
         
         <div class="card">
@@ -794,6 +795,7 @@ async function startServer() {
     
     app.listen(PORT, '0.0.0.0', () => {
         console.log(`Glance server running on port ${PORT}`);
+        console.log(`Docker image version: ${IMAGE_VERSION} (built ${BUILD_DATE})`);
         console.log(`Access the web interface at http://localhost:${PORT}`);
         console.log(`API endpoint for ESP32: http://localhost:${PORT}/api/current.json`);
     });


### PR DESCRIPTION
## Summary
- show build date and image version in server dashboard
- log version details on server start
- pass commit and build date as build arguments in Dockerfile
- allow docker-compose to inject IMAGE_VERSION and BUILD_DATE
- update local and push scripts to include build metadata

## Testing
- `npm install`
- `node server.js` (checked output)
- `curl http://localhost:3000 | grep -A1 "Docker Image"`

------
https://chatgpt.com/codex/tasks/task_b_6888e8d19a30832ba4c1a420f7802022