### PR TITLE
Add server page preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,39 @@
+name: PR Server Page Preview
+
+on:
+  pull_request:
+    paths:
+      - 'server/web-interface.js'
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install server dependencies
+        run: npm ci
+        working-directory: server
+
+      - name: Start server
+        run: |
+          node server.js &
+          npx wait-on http://localhost:3000
+        working-directory: server
+
+      - name: Install Puppeteer
+        run: npm install puppeteer --no-save
+
+      - name: Generate preview
+        run: node scripts/pr-preview.js
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: preview.md

--- a/scripts/pr-preview.js
+++ b/scripts/pr-preview.js
@@ -1,0 +1,11 @@
+const puppeteer = require('puppeteer');
+const fs = require('fs');
+
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.goto('http://localhost:3000', { waitUntil: 'networkidle0' });
+  const data = await page.screenshot({ encoding: 'base64', fullPage: true });
+  await browser.close();
+  fs.writeFileSync('preview.md', `![Server Preview](data:image/png;base64,${data})`);
+})();


### PR DESCRIPTION
## Summary
- add PR workflow to preview server page on PRs modifying web interface
- create script to capture screenshot using Puppeteer

## Testing
- `npm test` *(fails: Missing script `test`)*
- `node scripts/pr-preview.js` *(fails: Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_b_6888e88f5eb8832bb79a02da2fae4a9c