### PR TITLE
Improve CI build speed with caching

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -87,6 +87,8 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         build-args: |
           IMAGE_VERSION=${{ github.sha }}
           BUILD_DATE=${{ github.event.head_commit.timestamp }}


### PR DESCRIPTION
## Summary
- enable caching for Docker build step in GitHub Actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688d21e66e08832b99858273c0e28ee1