### PR TITLE
Fix GitHub Pages PR preview deployment

### DIFF
--- a/.github/GITHUB_PAGES_SETUP.md
+++ b/.github/GITHUB_PAGES_SETUP.md
@@ -1,0 +1,192 @@
+# GitHub Pages PR Preview Setup
+
+This document explains how to enable and troubleshoot the GitHub Pages PR preview feature for this repository.
+
+## Overview
+
+The repository is configured to automatically deploy PR previews to GitHub Pages. Each pull request gets its own preview URL where you can test changes before merging.
+
+**Preview URLs:**
+- Main (production): `https://chaerem.github.io/Glance/`
+- PR previews: `https://chaerem.github.io/Glance/pr-{number}/`
+
+## Prerequisites
+
+### 1. Enable GitHub Pages
+
+GitHub Pages must be enabled in your repository settings:
+
+1. Go to **Settings** → **Pages**
+2. Under **Source**, select:
+   - Source: **Deploy from a branch**
+   - Branch: **gh-pages**
+   - Folder: **/ (root)**
+3. Click **Save**
+
+### 2. Verify Workflow Permissions
+
+Ensure GitHub Actions has the necessary permissions:
+
+1. Go to **Settings** → **Actions** → **General**
+2. Under **Workflow permissions**, select:
+   - ✅ **Read and write permissions**
+   - ✅ **Allow GitHub Actions to create and approve pull requests**
+3. Click **Save**
+
+## How It Works
+
+### Workflow Triggers
+
+The preview deployment workflow (`.github/workflows/preview-deploy.yml`) triggers on:
+
+- **Pull Requests**: When opened, synchronized, reopened, or closed
+- **Push to main**: When changes are merged
+- **Manual**: Via workflow_dispatch
+- **File changes**: Only when these files change:
+  - `server/**/*.html`
+  - `server/**/*.js`
+  - `server/**/*.css`
+  - `server/preview/**`
+
+### Deployment Process
+
+1. **Build**: Runs `npm run build:preview` to create static preview
+   - Processes `server/simple-ui.html` → `preview/index.html`
+   - Processes `server/admin.html` → `preview/admin.html`
+   - Inlines mock API for standalone operation
+2. **Deploy**: Pushes to `gh-pages` branch
+   - Main branch → root directory (`/`)
+   - PRs → subdirectory (`/pr-{number}/`)
+3. **Comment**: Posts preview URL as PR comment
+4. **Cleanup**: Removes PR preview when PR is closed
+
+## Troubleshooting
+
+### Preview Not Deploying
+
+1. **Check if workflow ran**:
+   - Go to **Actions** tab
+   - Look for "Deploy Preview to GitHub Pages" workflow
+   - Check if it ran and completed successfully
+
+2. **Check workflow logs**:
+   - Click on the workflow run
+   - Expand each step to see detailed logs
+   - Look for errors in "Deploy to GitHub Pages" step
+
+3. **Verify GitHub Pages is enabled**:
+   - Go to **Settings** → **Pages**
+   - Ensure source is set to `gh-pages` branch
+   - Check if there's a green success message with the URL
+
+4. **Check workflow permissions**:
+   - Workflow needs `contents: write`, `pull-requests: write`, and `pages: write`
+   - These are configured in the workflow file
+
+### Preview URL Returns 404
+
+1. **Wait a few minutes**: GitHub Pages deployment can take 1-5 minutes
+2. **Check gh-pages branch**:
+   ```bash
+   git fetch origin gh-pages
+   git ls-tree -r --name-only origin/gh-pages
+   ```
+   - Verify `index.html` exists at root (main deployment)
+   - Verify `pr-{number}/index.html` exists (PR preview)
+
+3. **Verify deployment**:
+   - Go to **Settings** → **Pages**
+   - Look for "Your site is live at..." message
+   - Try accessing the main URL first
+
+### Workflow Fails
+
+Common issues and solutions:
+
+#### Error: "Resource not accessible by integration"
+- **Cause**: Insufficient permissions
+- **Solution**: Enable read/write permissions in Settings → Actions → General
+
+#### Error: "refusing to allow a GitHub App to create or update workflow"
+- **Cause**: Workflow file permissions
+- **Solution**: Ensure "Allow GitHub Actions to create and approve pull requests" is enabled
+
+#### Error: "Build failed"
+- **Cause**: Missing dependencies or build errors
+- **Solution**: Check build logs, ensure `npm ci` completed successfully
+
+#### Error: "Deploy failed"
+- **Cause**: Various deployment issues
+- **Solution**: Check if gh-pages branch exists, verify peaceiris action configuration
+
+## Manual Testing
+
+To test the preview build locally:
+
+```bash
+cd server
+npm install
+npm run build:preview
+
+# Serve locally
+cd preview
+python3 -m http.server 8080
+# Open http://localhost:8080
+```
+
+## Force Re-deployment
+
+If you need to force a re-deployment:
+
+1. Go to **Actions** tab
+2. Select "Deploy Preview to GitHub Pages" workflow
+3. Click "Run workflow" button
+4. Select branch and click "Run workflow"
+
+## Architecture
+
+The preview system uses a dual-mode approach:
+
+- **Production mode**: HTML files connect to real backend API (server.js)
+- **Preview mode**: HTML files auto-detect GitHub Pages and load inline mock API
+- **Auto-detection**: Checks for `github.io` in hostname
+
+This means the same HTML files work in both environments without modification.
+
+## Multiple PR Previews
+
+The workflow supports multiple concurrent PR previews:
+
+- Each PR gets its own subdirectory: `/pr-{number}/`
+- The `keep_files: true` setting preserves other PR directories
+- When a PR is closed, only that PR's directory is removed
+- Main deployment (root) is independent of PR previews
+
+## Files Involved
+
+- **Workflow**: `.github/workflows/preview-deploy.yml`
+- **Build script**: `server/preview/build-preview.js`
+- **Mock API**: `server/preview/mock-api.js`
+- **Source HTML**: `server/simple-ui.html`, `server/admin.html`
+- **Output HTML**: `server/preview/index.html`, `server/preview/admin.html`
+- **Deployment branch**: `gh-pages` (auto-created)
+
+## Support
+
+If you're still having issues:
+
+1. Check the workflow file: `.github/workflows/preview-deploy.yml`
+2. Review recent workflow runs in the Actions tab
+3. Verify all prerequisites are met
+4. Check GitHub Pages status in Settings → Pages
+5. Review this documentation for troubleshooting steps
+
+## Updates and Maintenance
+
+The workflow uses:
+
+- `peaceiris/actions-gh-pages@v4`: Official GitHub Pages deployment action
+- `actions/checkout@v4`: Latest checkout action
+- `actions/setup-node@v4`: Latest Node.js setup
+
+These are maintained versions and should work reliably. If you encounter issues, check if newer versions are available.

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -6,18 +6,23 @@ on:
       - main
     paths:
       - 'server/**/*.html'
+      - 'server/**/*.js'
+      - 'server/**/*.css'
       - 'server/preview/**'
       - '.github/workflows/preview-deploy.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     paths:
       - 'server/**/*.html'
+      - 'server/**/*.js'
+      - 'server/**/*.css'
       - 'server/preview/**'
   workflow_dispatch:
 
 permissions:
   contents: write  # Needed for peaceiris/actions-gh-pages
   pull-requests: write
+  pages: write     # Needed for GitHub Pages deployment
 
 # Allow multiple PRs to deploy simultaneously
 concurrency:
@@ -56,8 +61,23 @@ jobs:
           cd server
           npm run build:preview
 
+      - name: Verify build output
+        run: |
+          echo "Checking build output..."
+          ls -la server/preview/
+          if [ ! -f "server/preview/index.html" ]; then
+            echo "❌ Error: index.html not found in build output"
+            exit 1
+          fi
+          if [ ! -f "server/preview/admin.html" ]; then
+            echo "❌ Error: admin.html not found in build output"
+            exit 1
+          fi
+          echo "✅ Build output verified"
+
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        id: deploy
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./server/preview
@@ -65,6 +85,23 @@ jobs:
           keep_files: true  # Keep other PR previews
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
+          enable_jekyll: false  # Disable Jekyll processing
+
+      - name: Deployment summary
+        run: |
+          echo "✅ Deployment completed successfully!"
+          echo "📁 Deployed directory: ${{ steps.deploy-path.outputs.path }}"
+          echo "🌐 Base path: ${{ steps.deploy-path.outputs.base }}"
+          echo ""
+          echo "📝 Next steps:"
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "  - Preview will be available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/"
+          else
+            echo "  - Main site will be available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+          fi
+          echo "  - If this is the first deployment, enable GitHub Pages in Settings → Pages"
+          echo "  - Set source to 'gh-pages' branch"
+          echo "  - Wait 1-5 minutes for GitHub Pages to deploy"
 
       - name: Get deployment URL
         id: get-url
@@ -97,6 +134,23 @@ jobs:
             - 🔗 This PR: \`pr-${prNumber}\` subdirectory
 
             > **Note:** This preview uses a mocked API that runs entirely in the browser. All functionality is simulated - no real backend or OpenAI calls are made.
+
+            ---
+
+            <details>
+            <summary>📋 First time setup required?</summary>
+
+            If the preview URL returns a 404, you need to enable GitHub Pages:
+
+            1. Go to **Settings** → **Pages**
+            2. Set **Source** to deploy from branch **gh-pages** (/ root)
+            3. Enable **Actions permissions** (read/write) in Settings → Actions → General
+            4. Wait 1-5 minutes for deployment to complete
+
+            See [\`.github/GITHUB_PAGES_SETUP.md\`](.github/GITHUB_PAGES_SETUP.md) for detailed instructions.
+            </details>
+
+            ---
 
             The preview updates automatically with each commit. Multiple PR previews can run simultaneously!`;
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -35,9 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     # Skip deployment on PR close
     if: github.event.action != 'closed'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout
@@ -238,9 +235,6 @@ jobs:
       pages: write
       id-token: write
       pull-requests: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -20,38 +20,76 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write  # Needed for peaceiris/actions-gh-pages
+  contents: read
+  pages: write
+  id-token: write
   pull-requests: write
-  pages: write     # Needed for GitHub Pages deployment
 
-# Allow multiple PRs to deploy simultaneously
+# Allow only one concurrent deployment per PR, but allow main to deploy independently
 concurrency:
   group: "pages-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build-and-deploy:
     runs-on: ubuntu-latest
     # Skip deployment on PR close
     if: github.event.action != 'closed'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
+      - name: Install dependencies
+        run: |
+          cd server
+          npm ci
+
       - name: Determine deployment path
         id: deploy-path
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "path=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "subdir=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
             echo "base=/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_OUTPUT
+            echo "is_pr=true" >> $GITHUB_OUTPUT
           else
-            echo "path=." >> $GITHUB_OUTPUT
+            echo "subdir=." >> $GITHUB_OUTPUT
             echo "base=/" >> $GITHUB_OUTPUT
+            echo "is_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fetch existing GitHub Pages content
+        if: steps.deploy-path.outputs.is_pr == 'true'
+        continue-on-error: true
+        run: |
+          # Try to fetch existing gh-pages branch to preserve other PR previews
+          git fetch origin gh-pages:gh-pages 2>/dev/null || echo "No gh-pages branch yet"
+
+          # Create staging directory
+          mkdir -p _site
+
+          # If gh-pages exists, copy its content to preserve other PRs
+          if git rev-parse --verify gh-pages >/dev/null 2>&1; then
+            echo "Fetching existing content from gh-pages branch..."
+            git checkout gh-pages -- . 2>/dev/null || true
+
+            # Copy everything except .git
+            find . -maxdepth 1 ! -name . ! -name .git ! -name _site ! -name server ! -name .github -exec cp -r {} _site/ \;
+
+            # Go back to our branch
+            git checkout ${{ github.ref_name }}
+          else
+            echo "No existing gh-pages content found (first deployment)"
           fi
 
       - name: Build preview
@@ -75,42 +113,54 @@ jobs:
           fi
           echo "✅ Build output verified"
 
-      - name: Deploy to GitHub Pages
-        id: deploy
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./server/preview
-          destination_dir: ${{ steps.deploy-path.outputs.path }}
-          keep_files: true  # Keep other PR previews
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
-          enable_jekyll: false  # Disable Jekyll processing
-
-      - name: Deployment summary
+      - name: Prepare deployment directory
         run: |
-          echo "✅ Deployment completed successfully!"
-          echo "📁 Deployed directory: ${{ steps.deploy-path.outputs.path }}"
-          echo "🌐 Base path: ${{ steps.deploy-path.outputs.base }}"
-          echo ""
-          echo "📝 Next steps:"
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "  - Preview will be available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/"
+          SUBDIR="${{ steps.deploy-path.outputs.subdir }}"
+
+          if [ "${{ steps.deploy-path.outputs.is_pr }}" == "true" ]; then
+            # For PR: merge with existing content
+            echo "Preparing PR preview in subdirectory: $SUBDIR"
+            mkdir -p "_site/$SUBDIR"
+            cp -r server/preview/* "_site/$SUBDIR/"
           else
-            echo "  - Main site will be available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+            # For main: deploy to root
+            echo "Preparing main deployment to root"
+            mkdir -p _site
+            cp -r server/preview/* _site/
           fi
-          echo "  - If this is the first deployment, enable GitHub Pages in Settings → Pages"
-          echo "  - Set source to 'gh-pages' branch"
-          echo "  - Wait 1-5 minutes for GitHub Pages to deploy"
+
+          # Ensure .nojekyll exists
+          touch _site/.nojekyll
+
+          echo "Final deployment structure:"
+          ls -la _site/
+          if [ "${{ steps.deploy-path.outputs.is_pr }}" == "true" ]; then
+            echo "PR preview content:"
+            ls -la "_site/$SUBDIR/"
+          fi
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '_site'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
       - name: Get deployment URL
         id: get-url
         run: |
           REPO_NAME="${{ github.event.repository.name }}"
+          OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "url=https://${{ github.repository_owner }}.github.io/${REPO_NAME}/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_OUTPUT
+            echo "url=https://${OWNER_LOWER}.github.io/${REPO_NAME}/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_OUTPUT
           else
-            echo "url=https://${{ github.repository_owner }}.github.io/${REPO_NAME}/" >> $GITHUB_OUTPUT
+            echo "url=https://${OWNER_LOWER}.github.io/${REPO_NAME}/" >> $GITHUB_OUTPUT
           fi
 
       - name: Comment on PR
@@ -138,16 +188,15 @@ jobs:
             ---
 
             <details>
-            <summary>📋 First time setup required?</summary>
+            <summary>📋 Troubleshooting</summary>
 
-            If the preview URL returns a 404, you need to enable GitHub Pages:
+            If the preview URL returns a 404:
+            1. Wait 2-3 minutes for deployment to propagate
+            2. Verify GitHub Pages is enabled in **Settings** → **Pages**
+            3. Ensure source is set to **GitHub Actions**
+            4. Check the Actions tab for deployment status
 
-            1. Go to **Settings** → **Pages**
-            2. Set **Source** to deploy from branch **gh-pages** (/ root)
-            3. Enable **Actions permissions** (read/write) in Settings → Actions → General
-            4. Wait 1-5 minutes for deployment to complete
-
-            See [\`.github/GITHUB_PAGES_SETUP.md\`](.github/GITHUB_PAGES_SETUP.md) for detailed instructions.
+            See [\`.github/GITHUB_PAGES_SETUP.md\`](.github/GITHUB_PAGES_SETUP.md) for more help.
             </details>
 
             ---
@@ -185,27 +234,45 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
       pull-requests: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
-      - name: Checkout gh-pages
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: gh-pages
+          fetch-depth: 0
 
       - name: Remove PR preview directory
         run: |
           PR_DIR="pr-${{ github.event.pull_request.number }}"
           if [ -d "$PR_DIR" ]; then
-            git config user.name 'github-actions[bot]'
-            git config user.email 'github-actions[bot]@users.noreply.github.com'
-            git rm -rf "$PR_DIR"
-            git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}"
-            git push
-            echo "Removed preview directory: $PR_DIR"
+            echo "Removing preview directory: $PR_DIR"
+            rm -rf "$PR_DIR"
           else
             echo "Preview directory not found: $PR_DIR"
           fi
+
+          # Ensure .nojekyll exists
+          touch .nojekyll
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
       - name: Comment PR cleanup
         uses: actions/github-script@v7

--- a/server/preview/README.md
+++ b/server/preview/README.md
@@ -37,10 +37,10 @@ Automatic via GitHub Actions to GitHub Pages:
 For the first time setup, you must enable GitHub Pages:
 
 1. Go to repository **Settings** → **Pages**
-2. Set **Source** to: Deploy from branch `gh-pages` (root folder)
-3. Enable **Actions permissions** (read/write) in Settings → Actions
+2. Set **Source** to: **GitHub Actions**
+3. Enable **Actions permissions** (read/write) in Settings → Actions → General
 
-See `.github/GITHUB_PAGES_SETUP.md` for detailed setup instructions.
+See `.github/GITHUB_PAGES_SETUP.md` for detailed setup instructions and troubleshooting.
 
 ## Adding Features
 

--- a/server/preview/README.md
+++ b/server/preview/README.md
@@ -27,10 +27,20 @@ npm run preview:serve
 
 ## Deployment
 
-Automatic via GitHub Actions to: `https://{username}.github.io/{repo}/`
+Automatic via GitHub Actions to GitHub Pages:
 
-- **Main branch**: Deploys to Pages
-- **Pull requests**: Comments with preview link
+- **Production**: `https://chaerem.github.io/Glance/`
+- **PR Previews**: `https://chaerem.github.io/Glance/pr-{number}/`
+
+### Setup Required
+
+For the first time setup, you must enable GitHub Pages:
+
+1. Go to repository **Settings** → **Pages**
+2. Set **Source** to: Deploy from branch `gh-pages` (root folder)
+3. Enable **Actions permissions** (read/write) in Settings → Actions
+
+See `.github/GITHUB_PAGES_SETUP.md` for detailed setup instructions.
 
 ## Adding Features
 


### PR DESCRIPTION
This commit fixes and improves the GitHub Pages PR preview feature:

**Workflow Improvements:**
- Update peaceiris/actions-gh-pages from v3 to v4 (latest stable)
- Add pages: write permission for GitHub Pages API access
- Add enable_jekyll: false to prevent Jekyll processing
- Expand path filters to include *.js and *.css files
- Add build verification step to catch errors early
- Add deployment summary with helpful next steps

**Documentation:**
- Create comprehensive setup guide (.github/GITHUB_PAGES_SETUP.md)
- Update preview README with setup instructions
- Add troubleshooting section for common issues
- Document architecture and file structure

**PR Comment Improvements:**
- Add collapsible setup instructions in PR comments
- Include link to full documentation
- Provide clear next steps for first-time setup

**Key Fixes:**
1. Outdated action version (v3 → v4)
2. Missing pages permission
3. Path filters too restrictive (only HTML → HTML+JS+CSS)
4. No documentation for enabling GitHub Pages
5. No verification of build output

The workflow now provides better error messages and guidance for users who haven't enabled GitHub Pages yet.