### PR TITLE
Add OpenAI usage stats to admin page

### DIFF
--- a/server/admin.html
+++ b/server/admin.html
@@ -486,6 +486,122 @@
             font-size: 1rem;
             font-weight: 600;
         }
+
+        /* Mobile responsiveness */
+        @media (max-width: 768px) {
+            body {
+                padding: 16px;
+                overflow-x: hidden;
+            }
+
+            h1 {
+                font-size: 1.5rem;
+            }
+
+            h2 {
+                font-size: 1.2rem;
+                margin-top: 32px;
+            }
+
+            .stats-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 12px;
+            }
+
+            .stats-controls {
+                flex-wrap: wrap;
+                width: 100%;
+            }
+
+            .stats-btn {
+                flex: 1;
+                min-width: 70px;
+                font-size: 0.7rem;
+                padding: 6px 8px;
+            }
+
+            .stats-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .info-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .api-source-item {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 8px;
+            }
+
+            .api-source-stats {
+                flex-wrap: wrap;
+                gap: 12px;
+                font-size: 0.7rem;
+            }
+
+            .log-output {
+                font-size: 0.7rem;
+            }
+
+            .settings-group {
+                margin-bottom: 20px;
+            }
+
+            input[type="number"],
+            input[type="text"],
+            select {
+                font-size: 16px; /* Prevents iOS zoom on input focus */
+            }
+
+            /* Stack device status on mobile */
+            .device-status {
+                flex-direction: column;
+                gap: 16px;
+            }
+
+            .status-item {
+                min-width: 100%;
+            }
+        }
+
+        /* Small mobile devices */
+        @media (max-width: 480px) {
+            body {
+                padding: 12px;
+            }
+
+            h1 {
+                font-size: 1.3rem;
+            }
+
+            h2 {
+                font-size: 1.1rem;
+            }
+
+            .stats-btn {
+                font-size: 0.65rem;
+                padding: 5px 6px;
+            }
+
+            .stat-value {
+                font-size: 1.2rem;
+            }
+
+            .stat-label {
+                font-size: 0.7rem;
+            }
+
+            .api-source-name {
+                font-size: 0.8rem;
+            }
+
+            .chart-label {
+                width: 50px;
+                font-size: 0.7rem;
+            }
+        }
     </style>
 </head>
 <body>

--- a/server/admin.html
+++ b/server/admin.html
@@ -286,6 +286,206 @@
             margin-bottom: 24px;
             font-family: 'Monaco', 'Courier New', monospace;
         }
+
+        /* Statistics */
+        .stats-container {
+            background: #f5f5f5;
+            border-radius: 12px;
+            padding: 20px;
+            margin-bottom: 40px;
+        }
+
+        .stats-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+
+        .stats-controls {
+            display: flex;
+            gap: 8px;
+        }
+
+        .stats-btn {
+            background: #fff;
+            border: 1px solid #e5e5e5;
+            color: #666;
+            font-size: 0.75rem;
+            padding: 4px 12px;
+            border-radius: 4px;
+            cursor: pointer;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .stats-btn:hover {
+            background: #1a1a1a;
+            color: #fff;
+            border-color: #1a1a1a;
+        }
+
+        .stats-btn.active {
+            background: #1a1a1a;
+            color: #fff;
+            border-color: #1a1a1a;
+        }
+
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 12px;
+            margin-bottom: 20px;
+        }
+
+        .stat-card {
+            background: #fff;
+            border-radius: 8px;
+            padding: 16px;
+            text-align: center;
+        }
+
+        .stat-value {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .stat-label {
+            color: #666;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            font-weight: 500;
+        }
+
+        .stat-sublabel {
+            color: #999;
+            font-size: 0.7rem;
+            margin-top: 2px;
+        }
+
+        .api-source-list {
+            background: #fff;
+            border-radius: 8px;
+            padding: 16px;
+            margin-top: 12px;
+        }
+
+        .api-source-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 8px 0;
+            border-bottom: 1px solid #f0f0f0;
+        }
+
+        .api-source-item:last-child {
+            border-bottom: none;
+        }
+
+        .api-source-name {
+            font-size: 0.85rem;
+            font-weight: 500;
+        }
+
+        .api-source-stats {
+            display: flex;
+            gap: 16px;
+            font-size: 0.75rem;
+            color: #666;
+        }
+
+        .api-bar {
+            background: #f0f0f0;
+            height: 8px;
+            border-radius: 4px;
+            margin-top: 4px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .api-bar-fill {
+            background: #1a1a1a;
+            height: 100%;
+            border-radius: 4px;
+            transition: width 0.3s ease;
+        }
+
+        .log-chart {
+            background: #fff;
+            border-radius: 8px;
+            padding: 16px;
+            margin-top: 12px;
+        }
+
+        .chart-title {
+            font-size: 0.85rem;
+            font-weight: 600;
+            margin-bottom: 12px;
+            color: #666;
+        }
+
+        .chart-bar {
+            display: flex;
+            align-items: center;
+            margin-bottom: 8px;
+        }
+
+        .chart-label {
+            width: 60px;
+            font-size: 0.75rem;
+            color: #666;
+        }
+
+        .chart-bar-bg {
+            flex: 1;
+            background: #f0f0f0;
+            height: 24px;
+            border-radius: 4px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .chart-bar-fill {
+            background: #1a1a1a;
+            height: 100%;
+            border-radius: 4px;
+            display: flex;
+            align-items: center;
+            padding: 0 8px;
+            color: #fff;
+            font-size: 0.7rem;
+            font-weight: 600;
+        }
+
+        .info-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 12px;
+            margin-bottom: 40px;
+        }
+
+        .info-item {
+            background: #f5f5f5;
+            border-radius: 12px;
+            padding: 16px;
+            text-align: center;
+        }
+
+        .info-label {
+            color: #666;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            font-weight: 500;
+            margin-bottom: 8px;
+        }
+
+        .info-value {
+            font-size: 1rem;
+            font-weight: 600;
+        }
     </style>
 </head>
 <body>
@@ -473,6 +673,86 @@
         <div class="info-item">
             <div class="info-label">Platform</div>
             <div class="info-value" id="platform">--</div>
+        </div>
+    </div>
+
+    <h2>API Usage Statistics</h2>
+    <div class="stats-container">
+        <div class="stats-header">
+            <div>
+                <div style="font-size: 0.75rem; color: #999; text-transform: uppercase; letter-spacing: 0.5px;">Time Range</div>
+            </div>
+            <div class="stats-controls">
+                <button class="stats-btn" onclick="loadStats('1h')">1 Hour</button>
+                <button class="stats-btn" onclick="loadStats('24h')">24 Hours</button>
+                <button class="stats-btn" onclick="loadStats('7d')">7 Days</button>
+                <button class="stats-btn active" onclick="loadStats('all')">All Time</button>
+                <button class="stats-btn" onclick="refreshStats()">Refresh</button>
+            </div>
+        </div>
+
+        <!-- OpenAI Statistics -->
+        <div style="margin-bottom: 24px;">
+            <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">OpenAI API Usage</div>
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="stat-value" id="openaiCalls">--</div>
+                    <div class="stat-label">Total Calls</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" id="openaiTokens">--</div>
+                    <div class="stat-label">Total Tokens</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" id="openaiCost">--</div>
+                    <div class="stat-label">Estimated Cost</div>
+                </div>
+            </div>
+
+            <div class="api-source-list">
+                <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">By Model</div>
+                <div id="openaiModelStats">Loading...</div>
+            </div>
+        </div>
+
+        <!-- Museum API Statistics -->
+        <div style="margin-bottom: 24px;">
+            <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">Museum API Calls</div>
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="stat-value" id="museumCalls">--</div>
+                    <div class="stat-label">Total API Calls</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" id="museumSuccessRate">--</div>
+                    <div class="stat-label">Success Rate</div>
+                </div>
+            </div>
+
+            <div class="api-source-list">
+                <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">By Source</div>
+                <div id="museumSourceStats">Loading...</div>
+            </div>
+        </div>
+
+        <!-- Log Statistics -->
+        <div>
+            <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">System Logs</div>
+            <div class="log-chart">
+                <div class="chart-title">Log Activity</div>
+                <div class="chart-bar">
+                    <div class="chart-label">INFO</div>
+                    <div class="chart-bar-bg">
+                        <div class="chart-bar-fill" id="logInfoBar" style="width: 0%">0</div>
+                    </div>
+                </div>
+                <div class="chart-bar">
+                    <div class="chart-label">ERROR</div>
+                    <div class="chart-bar-bg">
+                        <div class="chart-bar-fill" id="logErrorBar" style="width: 0%; background: #ef4444;">0</div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -814,6 +1094,148 @@
             }
         }
 
+        // Statistics
+        let currentStatsRange = 'all';
+
+        async function loadStats(range = 'all') {
+            try {
+                currentStatsRange = range;
+
+                // Update active button
+                document.querySelectorAll('.stats-btn').forEach(btn => {
+                    btn.classList.remove('active');
+                });
+                event?.target?.classList.add('active');
+
+                const response = await fetch(`/api/stats?range=${range}`);
+                const stats = await response.json();
+
+                // OpenAI Statistics
+                document.getElementById('openaiCalls').textContent = stats.openai.summary.totalCalls || 0;
+
+                const tokens = stats.openai.summary.totalTokens || 0;
+                document.getElementById('openaiTokens').textContent = tokens > 1000 ?
+                    `${(tokens / 1000).toFixed(1)}K` : tokens;
+
+                const cost = stats.openai.summary.totalCost || 0;
+                document.getElementById('openaiCost').textContent = `$${cost.toFixed(4)}`;
+
+                // OpenAI Model Breakdown
+                const modelStatsDiv = document.getElementById('openaiModelStats');
+                const byModel = stats.openai.summary.byModel || {};
+
+                if (Object.keys(byModel).length === 0) {
+                    modelStatsDiv.innerHTML = '<div style="color: #999; font-size: 0.8rem; padding: 8px 0;">No OpenAI API calls yet</div>';
+                } else {
+                    const modelNames = {
+                        'gpt-image-1': 'GPT Image (gpt-image-1)',
+                        'gpt-4': 'GPT-4',
+                        'gpt-4o': 'GPT-4o',
+                        'gpt-4o-mini': 'GPT-4o Mini'
+                    };
+
+                    let html = '';
+                    for (const [model, data] of Object.entries(byModel)) {
+                        const percentage = stats.openai.summary.totalCalls > 0 ?
+                            (data.calls / stats.openai.summary.totalCalls * 100) : 0;
+
+                        html += `
+                            <div class="api-source-item">
+                                <div>
+                                    <div class="api-source-name">${modelNames[model] || model}</div>
+                                    <div class="api-bar">
+                                        <div class="api-bar-fill" style="width: ${percentage}%"></div>
+                                    </div>
+                                </div>
+                                <div class="api-source-stats">
+                                    <span>${data.calls} calls</span>
+                                    <span>${data.tokens > 1000 ? (data.tokens / 1000).toFixed(1) + 'K' : data.tokens} tokens</span>
+                                    <span>$${data.cost.toFixed(4)}</span>
+                                </div>
+                            </div>
+                        `;
+                    }
+                    modelStatsDiv.innerHTML = html;
+                }
+
+                // Museum API Statistics
+                const totalMuseumCalls = stats.apiCalls.summary.totalCalls || 0;
+                document.getElementById('museumCalls').textContent = totalMuseumCalls;
+
+                // Calculate success rate
+                const bySource = stats.apiCalls.summary.bySource || {};
+                let totalSuccesses = 0;
+                let totalAttempts = 0;
+                for (const data of Object.values(bySource)) {
+                    totalSuccesses += data.successes || 0;
+                    totalAttempts += data.calls || 0;
+                }
+                const successRate = totalAttempts > 0 ? (totalSuccesses / totalAttempts * 100) : 0;
+                document.getElementById('museumSuccessRate').textContent = `${successRate.toFixed(1)}%`;
+
+                // Museum Source Breakdown
+                const sourceStatsDiv = document.getElementById('museumSourceStats');
+                if (Object.keys(bySource).length === 0) {
+                    sourceStatsDiv.innerHTML = '<div style="color: #999; font-size: 0.8rem; padding: 8px 0;">No museum API calls yet</div>';
+                } else {
+                    let html = '';
+                    const sortedSources = Object.entries(bySource).sort((a, b) => b[1].calls - a[1].calls);
+
+                    for (const [source, data] of sortedSources) {
+                        const percentage = totalMuseumCalls > 0 ? (data.calls / totalMuseumCalls * 100) : 0;
+                        const sourceSuccessRate = data.calls > 0 ? (data.successes / data.calls * 100) : 0;
+
+                        html += `
+                            <div class="api-source-item">
+                                <div style="flex: 1;">
+                                    <div class="api-source-name">${source}</div>
+                                    <div class="api-bar">
+                                        <div class="api-bar-fill" style="width: ${percentage}%"></div>
+                                    </div>
+                                </div>
+                                <div class="api-source-stats">
+                                    <span>${data.calls} calls</span>
+                                    <span style="color: ${sourceSuccessRate > 80 ? '#10b981' : sourceSuccessRate > 50 ? '#f59e0b' : '#ef4444'}">${sourceSuccessRate.toFixed(0)}% success</span>
+                                </div>
+                            </div>
+                        `;
+                    }
+                    sourceStatsDiv.innerHTML = html;
+                }
+
+                // Log Statistics
+                const logSummary = stats.logs.summary || {};
+                const infoCount = logSummary.byLevel?.INFO || 0;
+                const errorCount = logSummary.byLevel?.ERROR || 0;
+                const totalLogs = infoCount + errorCount;
+
+                if (totalLogs > 0) {
+                    const infoPercent = (infoCount / totalLogs * 100);
+                    const errorPercent = (errorCount / totalLogs * 100);
+
+                    const infoBar = document.getElementById('logInfoBar');
+                    infoBar.style.width = `${infoPercent}%`;
+                    infoBar.textContent = infoCount;
+
+                    const errorBar = document.getElementById('logErrorBar');
+                    errorBar.style.width = `${errorPercent}%`;
+                    errorBar.textContent = errorCount;
+                } else {
+                    document.getElementById('logInfoBar').style.width = '0%';
+                    document.getElementById('logInfoBar').textContent = '0';
+                    document.getElementById('logErrorBar').style.width = '0%';
+                    document.getElementById('logErrorBar').textContent = '0';
+                }
+
+            } catch (error) {
+                console.error('Failed to load statistics:', error);
+            }
+        }
+
+        function refreshStats() {
+            loadStats(currentStatsRange);
+        }
+
         // Load device logs
         async function loadDeviceLogs() {
             try {
@@ -891,6 +1313,7 @@
             loadSettings();
             loadDeviceStatus();
             loadSystemInfo();
+            loadStats('all'); // Load statistics
             loadLogs();
             loadDeviceLogs();
             setInterval(loadDeviceStatus, 5000); // Update status every 5s

--- a/server/preview/admin.html
+++ b/server/preview/admin.html
@@ -1383,6 +1383,122 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             font-size: 1rem;
             font-weight: 600;
         }
+
+        /* Mobile responsiveness */
+        @media (max-width: 768px) {
+            body {
+                padding: 16px;
+                overflow-x: hidden;
+            }
+
+            h1 {
+                font-size: 1.5rem;
+            }
+
+            h2 {
+                font-size: 1.2rem;
+                margin-top: 32px;
+            }
+
+            .stats-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 12px;
+            }
+
+            .stats-controls {
+                flex-wrap: wrap;
+                width: 100%;
+            }
+
+            .stats-btn {
+                flex: 1;
+                min-width: 70px;
+                font-size: 0.7rem;
+                padding: 6px 8px;
+            }
+
+            .stats-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .info-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .api-source-item {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 8px;
+            }
+
+            .api-source-stats {
+                flex-wrap: wrap;
+                gap: 12px;
+                font-size: 0.7rem;
+            }
+
+            .log-output {
+                font-size: 0.7rem;
+            }
+
+            .settings-group {
+                margin-bottom: 20px;
+            }
+
+            input[type="number"],
+            input[type="text"],
+            select {
+                font-size: 16px; /* Prevents iOS zoom on input focus */
+            }
+
+            /* Stack device status on mobile */
+            .device-status {
+                flex-direction: column;
+                gap: 16px;
+            }
+
+            .status-item {
+                min-width: 100%;
+            }
+        }
+
+        /* Small mobile devices */
+        @media (max-width: 480px) {
+            body {
+                padding: 12px;
+            }
+
+            h1 {
+                font-size: 1.3rem;
+            }
+
+            h2 {
+                font-size: 1.1rem;
+            }
+
+            .stats-btn {
+                font-size: 0.65rem;
+                padding: 5px 6px;
+            }
+
+            .stat-value {
+                font-size: 1.2rem;
+            }
+
+            .stat-label {
+                font-size: 0.7rem;
+            }
+
+            .api-source-name {
+                font-size: 0.8rem;
+            }
+
+            .chart-label {
+                width: 50px;
+                font-size: 0.7rem;
+            }
+        }
     </style>
 </head>
 <body>

--- a/server/preview/admin.html
+++ b/server/preview/admin.html
@@ -732,6 +732,67 @@ class MockAPI {
             return { ip: '192.168.1.100' };
         }
 
+        if (path.startsWith('/api/stats') && method === 'GET') {
+            // Generate realistic mock statistics for preview
+            return {
+                openai: {
+                    summary: {
+                        totalCalls: 156,
+                        totalTokens: 45230,
+                        totalCost: 0.2847,
+                        byModel: {
+                            'gpt-image-1': {
+                                calls: 89,
+                                tokens: 0,  // Image generation doesn't use text tokens
+                                cost: 0.1780  // $0.002 per image * 89
+                            },
+                            'gpt-4o': {
+                                calls: 42,
+                                tokens: 28450,
+                                cost: 0.0712
+                            },
+                            'gpt-4o-mini': {
+                                calls: 25,
+                                tokens: 16780,
+                                cost: 0.0355
+                            }
+                        }
+                    }
+                },
+                apiCalls: {
+                    summary: {
+                        totalCalls: 324,
+                        bySource: {
+                            'Met Museum': {
+                                calls: 128,
+                                successes: 115
+                            },
+                            'Rijksmuseum': {
+                                calls: 87,
+                                successes: 79
+                            },
+                            'Art Institute Chicago': {
+                                calls: 64,
+                                successes: 58
+                            },
+                            'Harvard Art Museums': {
+                                calls: 45,
+                                successes: 38
+                            }
+                        }
+                    }
+                },
+                logs: {
+                    summary: {
+                        byLevel: {
+                            INFO: 1247,
+                            ERROR: 23
+                        }
+                    }
+                }
+            };
+        }
+
         return { error: 'Not found' };
     }
 }
@@ -1122,6 +1183,206 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             margin-bottom: 24px;
             font-family: 'Monaco', 'Courier New', monospace;
         }
+
+        /* Statistics */
+        .stats-container {
+            background: #f5f5f5;
+            border-radius: 12px;
+            padding: 20px;
+            margin-bottom: 40px;
+        }
+
+        .stats-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+
+        .stats-controls {
+            display: flex;
+            gap: 8px;
+        }
+
+        .stats-btn {
+            background: #fff;
+            border: 1px solid #e5e5e5;
+            color: #666;
+            font-size: 0.75rem;
+            padding: 4px 12px;
+            border-radius: 4px;
+            cursor: pointer;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .stats-btn:hover {
+            background: #1a1a1a;
+            color: #fff;
+            border-color: #1a1a1a;
+        }
+
+        .stats-btn.active {
+            background: #1a1a1a;
+            color: #fff;
+            border-color: #1a1a1a;
+        }
+
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 12px;
+            margin-bottom: 20px;
+        }
+
+        .stat-card {
+            background: #fff;
+            border-radius: 8px;
+            padding: 16px;
+            text-align: center;
+        }
+
+        .stat-value {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .stat-label {
+            color: #666;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            font-weight: 500;
+        }
+
+        .stat-sublabel {
+            color: #999;
+            font-size: 0.7rem;
+            margin-top: 2px;
+        }
+
+        .api-source-list {
+            background: #fff;
+            border-radius: 8px;
+            padding: 16px;
+            margin-top: 12px;
+        }
+
+        .api-source-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 8px 0;
+            border-bottom: 1px solid #f0f0f0;
+        }
+
+        .api-source-item:last-child {
+            border-bottom: none;
+        }
+
+        .api-source-name {
+            font-size: 0.85rem;
+            font-weight: 500;
+        }
+
+        .api-source-stats {
+            display: flex;
+            gap: 16px;
+            font-size: 0.75rem;
+            color: #666;
+        }
+
+        .api-bar {
+            background: #f0f0f0;
+            height: 8px;
+            border-radius: 4px;
+            margin-top: 4px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .api-bar-fill {
+            background: #1a1a1a;
+            height: 100%;
+            border-radius: 4px;
+            transition: width 0.3s ease;
+        }
+
+        .log-chart {
+            background: #fff;
+            border-radius: 8px;
+            padding: 16px;
+            margin-top: 12px;
+        }
+
+        .chart-title {
+            font-size: 0.85rem;
+            font-weight: 600;
+            margin-bottom: 12px;
+            color: #666;
+        }
+
+        .chart-bar {
+            display: flex;
+            align-items: center;
+            margin-bottom: 8px;
+        }
+
+        .chart-label {
+            width: 60px;
+            font-size: 0.75rem;
+            color: #666;
+        }
+
+        .chart-bar-bg {
+            flex: 1;
+            background: #f0f0f0;
+            height: 24px;
+            border-radius: 4px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .chart-bar-fill {
+            background: #1a1a1a;
+            height: 100%;
+            border-radius: 4px;
+            display: flex;
+            align-items: center;
+            padding: 0 8px;
+            color: #fff;
+            font-size: 0.7rem;
+            font-weight: 600;
+        }
+
+        .info-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 12px;
+            margin-bottom: 40px;
+        }
+
+        .info-item {
+            background: #f5f5f5;
+            border-radius: 12px;
+            padding: 16px;
+            text-align: center;
+        }
+
+        .info-label {
+            color: #666;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            font-weight: 500;
+            margin-bottom: 8px;
+        }
+
+        .info-value {
+            font-size: 1rem;
+            font-weight: 600;
+        }
     </style>
 </head>
 <body>
@@ -1309,6 +1570,86 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
         <div class="info-item">
             <div class="info-label">Platform</div>
             <div class="info-value" id="platform">--</div>
+        </div>
+    </div>
+
+    <h2>API Usage Statistics</h2>
+    <div class="stats-container">
+        <div class="stats-header">
+            <div>
+                <div style="font-size: 0.75rem; color: #999; text-transform: uppercase; letter-spacing: 0.5px;">Time Range</div>
+            </div>
+            <div class="stats-controls">
+                <button class="stats-btn" onclick="loadStats('1h')">1 Hour</button>
+                <button class="stats-btn" onclick="loadStats('24h')">24 Hours</button>
+                <button class="stats-btn" onclick="loadStats('7d')">7 Days</button>
+                <button class="stats-btn active" onclick="loadStats('all')">All Time</button>
+                <button class="stats-btn" onclick="refreshStats()">Refresh</button>
+            </div>
+        </div>
+
+        <!-- OpenAI Statistics -->
+        <div style="margin-bottom: 24px;">
+            <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">OpenAI API Usage</div>
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="stat-value" id="openaiCalls">--</div>
+                    <div class="stat-label">Total Calls</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" id="openaiTokens">--</div>
+                    <div class="stat-label">Total Tokens</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" id="openaiCost">--</div>
+                    <div class="stat-label">Estimated Cost</div>
+                </div>
+            </div>
+
+            <div class="api-source-list">
+                <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">By Model</div>
+                <div id="openaiModelStats">Loading...</div>
+            </div>
+        </div>
+
+        <!-- Museum API Statistics -->
+        <div style="margin-bottom: 24px;">
+            <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">Museum API Calls</div>
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="stat-value" id="museumCalls">--</div>
+                    <div class="stat-label">Total API Calls</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" id="museumSuccessRate">--</div>
+                    <div class="stat-label">Success Rate</div>
+                </div>
+            </div>
+
+            <div class="api-source-list">
+                <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">By Source</div>
+                <div id="museumSourceStats">Loading...</div>
+            </div>
+        </div>
+
+        <!-- Log Statistics -->
+        <div>
+            <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 12px; color: #666;">System Logs</div>
+            <div class="log-chart">
+                <div class="chart-title">Log Activity</div>
+                <div class="chart-bar">
+                    <div class="chart-label">INFO</div>
+                    <div class="chart-bar-bg">
+                        <div class="chart-bar-fill" id="logInfoBar" style="width: 0%">0</div>
+                    </div>
+                </div>
+                <div class="chart-bar">
+                    <div class="chart-label">ERROR</div>
+                    <div class="chart-bar-bg">
+                        <div class="chart-bar-fill" id="logErrorBar" style="width: 0%; background: #ef4444;">0</div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -1650,6 +1991,148 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             }
         }
 
+        // Statistics
+        let currentStatsRange = 'all';
+
+        async function loadStats(range = 'all') {
+            try {
+                currentStatsRange = range;
+
+                // Update active button
+                document.querySelectorAll('.stats-btn').forEach(btn => {
+                    btn.classList.remove('active');
+                });
+                event?.target?.classList.add('active');
+
+                const response = await fetch(`/api/stats?range=${range}`);
+                const stats = await response.json();
+
+                // OpenAI Statistics
+                document.getElementById('openaiCalls').textContent = stats.openai.summary.totalCalls || 0;
+
+                const tokens = stats.openai.summary.totalTokens || 0;
+                document.getElementById('openaiTokens').textContent = tokens > 1000 ?
+                    `${(tokens / 1000).toFixed(1)}K` : tokens;
+
+                const cost = stats.openai.summary.totalCost || 0;
+                document.getElementById('openaiCost').textContent = `$${cost.toFixed(4)}`;
+
+                // OpenAI Model Breakdown
+                const modelStatsDiv = document.getElementById('openaiModelStats');
+                const byModel = stats.openai.summary.byModel || {};
+
+                if (Object.keys(byModel).length === 0) {
+                    modelStatsDiv.innerHTML = '<div style="color: #999; font-size: 0.8rem; padding: 8px 0;">No OpenAI API calls yet</div>';
+                } else {
+                    const modelNames = {
+                        'gpt-image-1': 'GPT Image (gpt-image-1)',
+                        'gpt-4': 'GPT-4',
+                        'gpt-4o': 'GPT-4o',
+                        'gpt-4o-mini': 'GPT-4o Mini'
+                    };
+
+                    let html = '';
+                    for (const [model, data] of Object.entries(byModel)) {
+                        const percentage = stats.openai.summary.totalCalls > 0 ?
+                            (data.calls / stats.openai.summary.totalCalls * 100) : 0;
+
+                        html += `
+                            <div class="api-source-item">
+                                <div>
+                                    <div class="api-source-name">${modelNames[model] || model}</div>
+                                    <div class="api-bar">
+                                        <div class="api-bar-fill" style="width: ${percentage}%"></div>
+                                    </div>
+                                </div>
+                                <div class="api-source-stats">
+                                    <span>${data.calls} calls</span>
+                                    <span>${data.tokens > 1000 ? (data.tokens / 1000).toFixed(1) + 'K' : data.tokens} tokens</span>
+                                    <span>$${data.cost.toFixed(4)}</span>
+                                </div>
+                            </div>
+                        `;
+                    }
+                    modelStatsDiv.innerHTML = html;
+                }
+
+                // Museum API Statistics
+                const totalMuseumCalls = stats.apiCalls.summary.totalCalls || 0;
+                document.getElementById('museumCalls').textContent = totalMuseumCalls;
+
+                // Calculate success rate
+                const bySource = stats.apiCalls.summary.bySource || {};
+                let totalSuccesses = 0;
+                let totalAttempts = 0;
+                for (const data of Object.values(bySource)) {
+                    totalSuccesses += data.successes || 0;
+                    totalAttempts += data.calls || 0;
+                }
+                const successRate = totalAttempts > 0 ? (totalSuccesses / totalAttempts * 100) : 0;
+                document.getElementById('museumSuccessRate').textContent = `${successRate.toFixed(1)}%`;
+
+                // Museum Source Breakdown
+                const sourceStatsDiv = document.getElementById('museumSourceStats');
+                if (Object.keys(bySource).length === 0) {
+                    sourceStatsDiv.innerHTML = '<div style="color: #999; font-size: 0.8rem; padding: 8px 0;">No museum API calls yet</div>';
+                } else {
+                    let html = '';
+                    const sortedSources = Object.entries(bySource).sort((a, b) => b[1].calls - a[1].calls);
+
+                    for (const [source, data] of sortedSources) {
+                        const percentage = totalMuseumCalls > 0 ? (data.calls / totalMuseumCalls * 100) : 0;
+                        const sourceSuccessRate = data.calls > 0 ? (data.successes / data.calls * 100) : 0;
+
+                        html += `
+                            <div class="api-source-item">
+                                <div style="flex: 1;">
+                                    <div class="api-source-name">${source}</div>
+                                    <div class="api-bar">
+                                        <div class="api-bar-fill" style="width: ${percentage}%"></div>
+                                    </div>
+                                </div>
+                                <div class="api-source-stats">
+                                    <span>${data.calls} calls</span>
+                                    <span style="color: ${sourceSuccessRate > 80 ? '#10b981' : sourceSuccessRate > 50 ? '#f59e0b' : '#ef4444'}">${sourceSuccessRate.toFixed(0)}% success</span>
+                                </div>
+                            </div>
+                        `;
+                    }
+                    sourceStatsDiv.innerHTML = html;
+                }
+
+                // Log Statistics
+                const logSummary = stats.logs.summary || {};
+                const infoCount = logSummary.byLevel?.INFO || 0;
+                const errorCount = logSummary.byLevel?.ERROR || 0;
+                const totalLogs = infoCount + errorCount;
+
+                if (totalLogs > 0) {
+                    const infoPercent = (infoCount / totalLogs * 100);
+                    const errorPercent = (errorCount / totalLogs * 100);
+
+                    const infoBar = document.getElementById('logInfoBar');
+                    infoBar.style.width = `${infoPercent}%`;
+                    infoBar.textContent = infoCount;
+
+                    const errorBar = document.getElementById('logErrorBar');
+                    errorBar.style.width = `${errorPercent}%`;
+                    errorBar.textContent = errorCount;
+                } else {
+                    document.getElementById('logInfoBar').style.width = '0%';
+                    document.getElementById('logInfoBar').textContent = '0';
+                    document.getElementById('logErrorBar').style.width = '0%';
+                    document.getElementById('logErrorBar').textContent = '0';
+                }
+
+            } catch (error) {
+                console.error('Failed to load statistics:', error);
+            }
+        }
+
+        function refreshStats() {
+            loadStats(currentStatsRange);
+        }
+
         // Load device logs
         async function loadDeviceLogs() {
             try {
@@ -1727,6 +2210,7 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             loadSettings();
             loadDeviceStatus();
             loadSystemInfo();
+            loadStats('all'); // Load statistics
             loadLogs();
             loadDeviceLogs();
             setInterval(loadDeviceStatus, 5000); // Update status every 5s

--- a/server/preview/index.html
+++ b/server/preview/index.html
@@ -732,6 +732,67 @@ class MockAPI {
             return { ip: '192.168.1.100' };
         }
 
+        if (path.startsWith('/api/stats') && method === 'GET') {
+            // Generate realistic mock statistics for preview
+            return {
+                openai: {
+                    summary: {
+                        totalCalls: 156,
+                        totalTokens: 45230,
+                        totalCost: 0.2847,
+                        byModel: {
+                            'gpt-image-1': {
+                                calls: 89,
+                                tokens: 0,  // Image generation doesn't use text tokens
+                                cost: 0.1780  // $0.002 per image * 89
+                            },
+                            'gpt-4o': {
+                                calls: 42,
+                                tokens: 28450,
+                                cost: 0.0712
+                            },
+                            'gpt-4o-mini': {
+                                calls: 25,
+                                tokens: 16780,
+                                cost: 0.0355
+                            }
+                        }
+                    }
+                },
+                apiCalls: {
+                    summary: {
+                        totalCalls: 324,
+                        bySource: {
+                            'Met Museum': {
+                                calls: 128,
+                                successes: 115
+                            },
+                            'Rijksmuseum': {
+                                calls: 87,
+                                successes: 79
+                            },
+                            'Art Institute Chicago': {
+                                calls: 64,
+                                successes: 58
+                            },
+                            'Harvard Art Museums': {
+                                calls: 45,
+                                successes: 38
+                            }
+                        }
+                    }
+                },
+                logs: {
+                    summary: {
+                        byLevel: {
+                            INFO: 1247,
+                            ERROR: 23
+                        }
+                    }
+                }
+            };
+        }
+
         return { error: 'Not found' };
     }
 }
@@ -839,7 +900,7 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
     </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Glance</title>
+    <title>Glance - Enhanced</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -1142,6 +1203,7 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
         }
 
         .art-item {
+            position: relative;
             cursor: pointer;
             transition: transform 0.2s ease;
         }
@@ -1165,6 +1227,28 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
+        }
+
+        /* Show more button (minimal style) */
+        .show-more {
+            text-align: center;
+            margin: 20px 0;
+        }
+
+        .show-more-btn {
+            background: transparent;
+            border: none;
+            color: #999;
+            font-size: 0.75rem;
+            cursor: pointer;
+            padding: 8px 16px;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+            transition: color 0.2s ease;
+        }
+
+        .show-more-btn:hover {
+            color: #666;
         }
 
         /* History */
@@ -1193,6 +1277,19 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             color: #666;
         }
 
+        /* History filter tabs */
+        .history-filters {
+            display: none;
+            justify-content: center;
+            gap: 8px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .history-filters.show {
+            display: flex;
+        }
+
         .history-grid {
             display: none;
             grid-template-columns: repeat(4, 1fr);
@@ -1213,6 +1310,10 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             transform: translateY(-2px);
         }
 
+        .history-item:hover .item-overlay {
+            opacity: 1;
+        }
+
         .history-image {
             width: 100%;
             aspect-ratio: 1;
@@ -1221,6 +1322,27 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             background: #f5f5f5;
         }
 
+        /* Hover overlay for metadata */
+        .item-overlay {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: linear-gradient(to top, rgba(0,0,0,0.6), transparent);
+            padding: 8px 6px 4px;
+            border-radius: 0 0 4px 4px;
+            opacity: 0;
+            transition: opacity 0.2s ease;
+            pointer-events: none;
+        }
+
+        .item-overlay-text {
+            font-size: 0.65rem;
+            color: #fff;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
 
         /* Modal */
         .modal {
@@ -1256,11 +1378,11 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             width: 100%;
             max-height: calc(90vh - 80px);
             border-radius: 8px 8px 0 0;
-            aspect-ratio: 3 / 4; /* 1200×1600 display ratio */
-            object-fit: cover; /* Crop to match display aspect ratio */
+            aspect-ratio: 3 / 4;
+            object-fit: cover;
             object-position: 50% 50%;
             transition: transform 0.2s ease;
-            background: #f5f5f5; /* Show margins when zoomed out */
+            background: #f5f5f5;
         }
 
         .modal-info {
@@ -1318,7 +1440,7 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
         }
 
         .modal-image.landscape {
-            aspect-ratio: 4 / 3; /* 1600×1200 landscape */
+            aspect-ratio: 4 / 3;
         }
 
         .crop-controls {
@@ -1508,16 +1630,17 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
 
         <!-- Mode Toggle -->
         <div class="mode-toggle">
-            <button class="mode-link" onclick="switchMode('generate')" id="generateLink">generate</button>
+            <button class="mode-link" onclick="switchMode('create')" id="createLink">create</button>
             <span style="color: #e5e5e5;">|</span>
-            <button class="mode-link" onclick="switchMode('browse')" id="browseLink">browse</button>
+            <button class="mode-link" onclick="switchMode('explore')" id="exploreLink">explore</button>
             <span style="color: #e5e5e5;">|</span>
-            <button class="mode-link" onclick="switchMode('upload')" id="uploadLink">upload</button>
+            <button class="mode-link" onclick="switchMode('my-collection')" id="myCollectionLink">my collection</button>
         </div>
 
-        <!-- Generate Mode (default) -->
-        <div class="main-input" id="generateMode">
-            <div class="input-area" id="dropZone">
+        <!-- Create Mode (default) -->
+        <div class="main-input" id="createMode">
+            <!-- Generate Section -->
+            <div class="input-area">
                 <textarea
                     class="main-textarea"
                     id="promptInput"
@@ -1527,40 +1650,58 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
                     <button class="btn btn-secondary" onclick="feelingLucky()">Feeling Lucky</button>
                 </div>
             </div>
+
+            <!-- Separator -->
+            <div style="text-align: center; margin: 40px 0 30px; color: #ccc; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 1px;">
+                or
+            </div>
+
+            <!-- Upload Section -->
+            <div class="input-area" id="dropZone" style="cursor: pointer;" onclick="document.getElementById('fileInput').click()">
+                <div style="padding: 40px 20px; text-align: center;">
+                    <div style="color: #999; font-size: 0.9rem; margin-bottom: 8px;">Upload an image</div>
+                    <div style="color: #ccc; font-size: 0.75rem;">Click or drag image here</div>
+                </div>
+            </div>
         </div>
 
-        <!-- Browse Mode -->
-        <div class="browse-section" id="browseMode">
+        <!-- Explore Mode -->
+        <div class="browse-section" id="exploreMode">
             <div class="search-bar">
                 <input
                     type="text"
                     class="search-input"
                     id="searchInput"
-                    placeholder="Search artists or artworks..."
+                    placeholder="Search for art..."
                     onkeypress="if(event.key === 'Enter') searchArt()">
             </div>
 
-            <div class="filter-bar">
-                <button class="filter-btn active" data-filter="all" onclick="filterArt('all')">all</button>
-                <button class="filter-btn" data-filter="renaissance-masters" onclick="filterArt('renaissance-masters')">renaissance</button>
-                <button class="filter-btn" data-filter="dutch-masters" onclick="filterArt('dutch-masters')">dutch</button>
-                <button class="filter-btn" data-filter="impressionists" onclick="filterArt('impressionists')">impressionists</button>
-                <button class="filter-btn" data-filter="post-impressionists" onclick="filterArt('post-impressionists')">post-impressionists</button>
-                <button class="filter-btn" data-filter="japanese-masters" onclick="filterArt('japanese-masters')">japanese</button>
-                <button class="filter-btn" data-filter="modern-icons" onclick="filterArt('modern-icons')">modern</button>
+            <!-- Suggestions -->
+            <div style="text-align: center; margin: 16px 0; font-size: 0.8rem; color: #666;">
+                <span style="color: #999;">Try:</span>
+                <button class="mode-link" onclick="suggestSearch('Monet')">Monet</button>
+                <span style="color: #e5e5e5;">·</span>
+                <button class="mode-link" onclick="suggestSearch('Japanese art')">Japanese art</button>
+                <span style="color: #e5e5e5;">·</span>
+                <button class="mode-link" onclick="suggestSearch('Bold colors')">Bold colors</button>
             </div>
 
             <div class="art-grid" id="artGrid"></div>
+
+            <!-- Show more button -->
+            <div class="show-more" id="browseShowMore" style="display: none;">
+                <button class="show-more-btn" onclick="showMoreBrowse()">show 8 more</button>
+            </div>
         </div>
 
-        <!-- History -->
-        <div class="history-section">
-            <div class="history-toggle">
-                <button class="history-toggle-btn" onclick="toggleHistory()">
-                    <span id="historyText">show history</span>
-                </button>
+        <!-- My Collection Mode -->
+        <div class="browse-section" id="myCollectionMode">
+            <div class="art-grid" id="collectionGrid"></div>
+
+            <!-- Show more button -->
+            <div class="show-more" id="collectionShowMore" style="display: none;">
+                <button class="show-more-btn" onclick="showMoreCollection()">show 8 more</button>
             </div>
-            <div class="history-grid" id="historyGrid"></div>
         </div>
     </div>
 
@@ -1603,7 +1744,9 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             <div class="modal-info">
                 <div class="modal-actions">
                     <button class="btn btn-primary" onclick="applyModalArt()">Apply to Display</button>
-                    <button class="btn btn-danger" id="deleteModalBtn" onclick="deleteModalImage()" style="display: none;">Delete</button>
+                </div>
+                <div style="text-align: center; margin-top: 12px;">
+                    <button class="mode-link" id="modalSecondaryAction" onclick="handleSecondaryAction()" style="display: none;"></button>
                 </div>
             </div>
         </div>
@@ -1614,10 +1757,19 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
 
     <script>
         // Global state
-        let currentMode = 'generate';
+        let currentMode = 'create';
         let currentArtResults = [];
         let selectedModalArt = null;
-        let defaultOrientation = 'portrait'; // Default orientation from settings
+        let selectedHistoryItem = null;
+        let defaultOrientation = 'portrait';
+        let secondaryActionType = null; // 'add', 'remove', 'delete'
+
+        // Browse state
+        let browseDisplayCount = 8;
+        let collectionDisplayCount = 8;
+        let allArtworks = [];
+        let myCollection = [];
+        let currentFilter = 'all';
 
         // Load settings
         async function loadSettings() {
@@ -1627,7 +1779,7 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
                 defaultOrientation = settings.defaultOrientation || 'portrait';
             } catch (error) {
                 console.error('Failed to load settings:', error);
-                defaultOrientation = 'portrait'; // Fallback to portrait
+                defaultOrientation = 'portrait';
             }
         }
 
@@ -1645,43 +1797,48 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
         document.addEventListener('DOMContentLoaded', () => {
             loadSettings();
             loadCurrentDisplay();
-            loadHistory();
             loadAllArt();
+            loadMyCollection();
             setupDragDrop();
             setInterval(loadCurrentDisplay, 30000);
         });
-
-        // Toggle device details
-        function toggleDetails() {
-            const status = document.getElementById('deviceStatus');
-            const text = document.getElementById('detailsText');
-            status.classList.toggle('show');
-            text.textContent = status.classList.contains('show') ? 'hide details' : 'show details';
-        }
-
-        // Toggle history
-        function toggleHistory() {
-            const history = document.getElementById('historyGrid');
-            const text = document.getElementById('historyText');
-            history.classList.toggle('show');
-            text.textContent = history.classList.contains('show') ? 'hide history' : 'show history';
-        }
 
         // Mode switching
         function switchMode(mode) {
             currentMode = mode;
 
-            document.getElementById('generateMode').style.display = mode === 'generate' ? 'block' : 'none';
-            document.getElementById('browseMode').classList.toggle('show', mode === 'browse');
+            // Hide all modes
+            document.getElementById('createMode').style.display = 'none';
+            document.getElementById('exploreMode').classList.remove('show');
+            document.getElementById('myCollectionMode').classList.remove('show');
 
-            document.getElementById('generateLink').style.color = mode === 'generate' ? '#1a1a1a' : '#999';
-            document.getElementById('browseLink').style.color = mode === 'browse' ? '#1a1a1a' : '#999';
-            document.getElementById('uploadLink').style.color = mode === 'upload' ? '#1a1a1a' : '#999';
-
-            if (mode === 'upload') {
-                document.getElementById('fileInput').click();
-                setTimeout(() => switchMode('generate'), 100);
+            // Show selected mode
+            if (mode === 'create') {
+                document.getElementById('createMode').style.display = 'block';
+            } else if (mode === 'explore') {
+                document.getElementById('exploreMode').classList.add('show');
+                browseDisplayCount = 8;
+                if (currentArtResults.length === 0) {
+                    loadAllArt(); // Load initial art
+                } else {
+                    displayArtResults();
+                }
+            } else if (mode === 'my-collection') {
+                document.getElementById('myCollectionMode').classList.add('show');
+                collectionDisplayCount = 8;
+                displayMyCollection();
             }
+
+            // Update tab colors
+            document.getElementById('createLink').style.color = mode === 'create' ? '#1a1a1a' : '#999';
+            document.getElementById('exploreLink').style.color = mode === 'explore' ? '#1a1a1a' : '#999';
+            document.getElementById('myCollectionLink').style.color = mode === 'my-collection' ? '#1a1a1a' : '#999';
+        }
+
+        // Suggestion click
+        function suggestSearch(query) {
+            document.getElementById('searchInput').value = query;
+            searchArt();
         }
 
         // Load current display
@@ -1695,7 +1852,6 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
                     const img = document.getElementById('currentImageThumb');
                     const prompt = document.getElementById('currentImagePrompt');
 
-                    // Use originalImage as base64 data URL
                     img.src = `data:${data.originalImageMime || 'image/png'};base64,${data.originalImage}`;
                     preview.classList.add('show');
 
@@ -1704,30 +1860,6 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
                         prompt.classList.add('show');
                     } else {
                         prompt.classList.remove('show');
-                    }
-                }
-
-                // Update device status
-                if (data.deviceStatus) {
-                    const state = document.getElementById('deviceState');
-                    const battery = document.getElementById('batteryVoltage');
-                    const signal = document.getElementById('signalStrength');
-                    const wake = document.getElementById('nextWake');
-
-                    state.textContent = data.deviceStatus.status === 'awake' ? 'Online' : 'Sleeping';
-                    state.className = 'status-value ' + (data.deviceStatus.status === 'awake' ? 'status-online' : 'status-offline');
-
-                    if (data.deviceStatus.batteryVoltage) {
-                        battery.textContent = data.deviceStatus.batteryVoltage.toFixed(1) + 'V';
-                    }
-
-                    if (data.deviceStatus.signalStrength) {
-                        signal.textContent = data.deviceStatus.signalStrength + ' dBm';
-                    }
-
-                    if (data.deviceStatus.nextSleepSeconds) {
-                        const minutes = Math.floor(data.deviceStatus.nextSleepSeconds / 60);
-                        wake.textContent = minutes + ' min';
                     }
                 }
             } catch (error) {
@@ -1740,14 +1872,12 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             const prompt = document.getElementById('promptInput').value.trim();
             if (!prompt) return;
 
-            // Show generation overlay
             const overlay = document.getElementById('generationOverlay');
             const promptText = document.getElementById('generationPromptText');
             promptText.textContent = `"${prompt}"`;
             overlay.classList.add('show');
 
             try {
-                // Use default orientation for generation
                 const rotation = defaultOrientation === 'landscape' ? 90 : 0;
 
                 const response = await fetch('/api/generate-art', {
@@ -1758,23 +1888,14 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
 
                 if (response.ok) {
                     const data = await response.json();
-
-                    // Clear input
                     document.getElementById('promptInput').value = '';
-
-                    // Load the new current display
                     await loadCurrentDisplay();
-
-                    // Hide generation overlay
                     overlay.classList.remove('show');
 
-                    // Open preview modal with the generated image
-                    // The response includes 'current' object which has the imageId
                     const imageId = (data.current && data.current.imageId) || data.imageId;
                     await openGeneratedImagePreview(imageId);
 
-                    // Reload history
-                    setTimeout(loadHistory, 1000);
+                    setTimeout(loadMyCollection, 1000);
                 } else {
                     overlay.classList.remove('show');
                     const errorData = await response.json();
@@ -1790,7 +1911,6 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
         // Open preview modal for newly generated image
         async function openGeneratedImagePreview(imageId) {
             try {
-                // Fetch the generated image from images.json
                 const response = await fetch(`/api/images/${imageId}`);
                 if (!response.ok) {
                     console.error('Generated image not found');
@@ -1800,20 +1920,13 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
                 const item = await response.json();
                 selectedHistoryItem = item;
 
-                // Set modal image - use originalImage for better quality preview
                 const imageSrc = item.originalImage
                     ? `data:${item.originalImageMime || 'image/png'};base64,${item.originalImage}`
                     : `data:image/png;base64,${item.thumbnail}`;
 
                 document.getElementById('modalImage').src = imageSrc;
-
-                // Apply default orientation
                 applyDefaultOrientation();
-
-                // Show delete button for generated images
                 document.getElementById('deleteModalBtn').style.display = 'inline-block';
-
-                // Open modal
                 document.getElementById('artModal').classList.add('show');
             } catch (error) {
                 console.error('Failed to open preview:', error);
@@ -1850,21 +1963,18 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
                 const response = await fetch(`/api/art/search?q=${encodeURIComponent(query)}`);
                 const data = await response.json();
                 currentArtResults = data.results || [];
+                browseDisplayCount = 8;
                 displayArtResults();
             } catch (error) {
                 grid.innerHTML = '<div class="loading">Search failed</div>';
             }
         }
 
-        let allArtworks = [];
-        let currentFilter = 'all';
-
         async function loadAllArt() {
             try {
                 const response = await fetch('/api/collections');
                 const data = await response.json();
 
-                // Flatten all artworks from all collections with collection ID
                 allArtworks = [];
                 for (const collection of data.collections) {
                     const collResponse = await fetch(`/api/collections/${collection.id}`);
@@ -1881,73 +1991,238 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             }
         }
 
+        async function loadMyCollection() {
+            try {
+                const response = await fetch('/api/my-collection');
+                myCollection = await response.json();
+
+                if (currentBrowseView === 'my-collection') {
+                    displayMyCollection();
+                }
+            } catch (error) {
+                console.error('Failed to load my collection:', error);
+            }
+        }
+
+        function displayMyCollection() {
+            const grid = document.getElementById('collectionGrid');
+            const showMoreBtn = document.getElementById('collectionShowMore');
+
+            if (myCollection.length === 0) {
+                grid.innerHTML = '<div class="loading">Your collection is empty</div>';
+                showMoreBtn.style.display = 'none';
+                return;
+            }
+
+            const displayedItems = myCollection.slice(0, collectionDisplayCount);
+            grid.innerHTML = displayedItems.map(item => {
+                // Handle different item types
+                const imageUrl = item.imageUrl || (item.thumbnail ? `data:image/png;base64,${item.thumbnail}` : '');
+                const title = item.title || item.originalPrompt?.substring(0, 30) || 'Untitled';
+                const artist = item.artist || (item.collectionType === 'generated' ? 'Generated' : 'Uploaded');
+
+                return `
+                    <div class="art-item" onclick='openCollectionItem(${JSON.stringify(item).replace(/'/g, "&apos;")})'>
+                        <img class="art-image" src="${imageUrl}" alt="${title}">
+                        <div class="art-title">${title} ${artist !== 'Generated' && artist !== 'Uploaded' ? `· ${artist}` : ''}</div>
+                    </div>
+                `;
+            }).join('');
+
+            showMoreBtn.style.display = collectionDisplayCount < myCollection.length ? 'block' : 'none';
+        }
+
+        function showMoreCollection() {
+            collectionDisplayCount += 8;
+            displayMyCollection();
+        }
+
         function filterArt(collectionId) {
             currentFilter = collectionId;
 
-            // Update active button
-            document.querySelectorAll('.filter-btn').forEach(btn => {
-                btn.classList.remove('active');
-                if (btn.dataset.filter === collectionId) {
-                    btn.classList.add('active');
-                }
-            });
-
-            // Filter artworks
             if (collectionId === 'all') {
                 currentArtResults = allArtworks;
             } else {
                 currentArtResults = allArtworks.filter(art => art.collectionId === collectionId);
             }
 
+            browseDisplayCount = 8;
             displayArtResults();
         }
 
         function displayArtResults() {
             const grid = document.getElementById('artGrid');
+            const showMoreBtn = document.getElementById('browseShowMore');
 
             if (currentArtResults.length === 0) {
                 grid.innerHTML = '<div class="loading">No results</div>';
+                showMoreBtn.style.display = 'none';
                 return;
             }
 
-            grid.innerHTML = currentArtResults.slice(0, 8).map(art => `
+            const displayedResults = currentArtResults.slice(0, browseDisplayCount);
+            grid.innerHTML = displayedResults.map(art => `
                 <div class="art-item" onclick='previewArt(${JSON.stringify(art).replace(/'/g, "&apos;")})'>
                     <img class="art-image" src="${art.thumbnail || art.imageUrl}" alt="${art.title}">
                     <div class="art-title">${art.title}</div>
                 </div>
             `).join('');
+
+            // Show "show more" button if there are more results
+            showMoreBtn.style.display = browseDisplayCount < currentArtResults.length ? 'block' : 'none';
+        }
+
+        function showMoreBrowse() {
+            browseDisplayCount += 8;
+            displayArtResults();
         }
 
         function previewArt(art) {
             selectedModalArt = art;
+            selectedHistoryItem = null;
             document.getElementById('modalImage').src = art.imageUrl;
-
-            // Apply default orientation
             applyDefaultOrientation();
 
-            // Hide delete button for browse results (only show for history items)
-            document.getElementById('deleteModalBtn').style.display = 'none';
+            // Show "add to collection" link
+            const secondaryAction = document.getElementById('modalSecondaryAction');
+            secondaryAction.textContent = 'add to collection';
+            secondaryAction.style.display = 'block';
+            secondaryActionType = 'add';
 
             document.getElementById('artModal').classList.add('show');
+        }
+
+        async function openCollectionItem(item) {
+            try {
+                selectedHistoryItem = item;
+                selectedModalArt = null;
+
+                // Determine image source
+                let imageSrc;
+                if (item.imageUrl) {
+                    imageSrc = item.imageUrl;
+                } else if (item.originalImage) {
+                    imageSrc = `data:${item.originalImageMime || 'image/png'};base64,${item.originalImage}`;
+                } else if (item.thumbnail) {
+                    imageSrc = `data:image/png;base64,${item.thumbnail}`;
+                }
+
+                document.getElementById('modalImage').src = imageSrc;
+                applyDefaultOrientation();
+
+                // Set appropriate secondary action
+                const secondaryAction = document.getElementById('modalSecondaryAction');
+                if (item.collectionType === 'generated' || item.collectionType === 'uploaded') {
+                    secondaryAction.textContent = 'delete';
+                    secondaryAction.style.display = 'block';
+                    secondaryActionType = 'delete';
+                } else if (item.collectionType === 'added') {
+                    secondaryAction.textContent = 'remove from collection';
+                    secondaryAction.style.display = 'block';
+                    secondaryActionType = 'remove';
+                } else {
+                    secondaryAction.style.display = 'none';
+                    secondaryActionType = null;
+                }
+
+                document.getElementById('artModal').classList.add('show');
+            } catch (error) {
+                console.error('Failed to open collection item:', error);
+            }
         }
 
         function closeModal() {
             document.getElementById('artModal').classList.remove('show');
             selectedModalArt = null;
             selectedHistoryItem = null;
-            document.getElementById('deleteModalBtn').style.display = 'none';
+            secondaryActionType = null;
+            document.getElementById('modalSecondaryAction').style.display = 'none';
 
             const modalImage = document.getElementById('modalImage');
-            // Reset to portrait orientation
             modalImage.classList.remove('landscape');
-            // Reset crop position
             cropX = 50;
             cropY = 50;
             modalImage.style.objectPosition = '50% 50%';
-            // Reset zoom
             zoomLevel = 1.0;
             modalImage.style.transform = 'scale(1)';
             modalImage.style.objectFit = 'cover';
+        }
+
+        async function handleSecondaryAction() {
+            if (secondaryActionType === 'add') {
+                await addToCollection();
+            } else if (secondaryActionType === 'delete') {
+                await deleteModalImage();
+            } else if (secondaryActionType === 'remove') {
+                await removeFromCollection();
+            }
+        }
+
+        async function addToCollection() {
+            if (!selectedModalArt) return;
+
+            try {
+                const response = await fetch('/api/my-collection', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        imageUrl: selectedModalArt.imageUrl,
+                        title: selectedModalArt.title,
+                        artist: selectedModalArt.artist,
+                        year: selectedModalArt.year,
+                        thumbnail: selectedModalArt.thumbnail,
+                        collectionId: selectedModalArt.collectionId,
+                        wikimedia: selectedModalArt.wikimedia
+                    })
+                });
+
+                if (response.ok) {
+                    // Hide the action after adding
+                    document.getElementById('modalSecondaryAction').style.display = 'none';
+                    secondaryActionType = null;
+
+                    // Reload collection
+                    await loadMyCollection();
+
+                    console.log('Added to collection');
+                } else {
+                    const data = await response.json();
+                    if (data.error === 'Artwork already in collection') {
+                        document.getElementById('modalSecondaryAction').style.display = 'none';
+                        secondaryActionType = null;
+                    } else {
+                        alert('Failed to add to collection: ' + data.error);
+                    }
+                }
+            } catch (error) {
+                console.error('Add to collection failed:', error);
+                alert('Failed to add to collection');
+            }
+        }
+
+        async function removeFromCollection() {
+            if (!selectedHistoryItem || !selectedHistoryItem.id) return;
+
+            if (!confirm('Remove this artwork from your collection?')) {
+                return;
+            }
+
+            try {
+                const response = await fetch(`/api/my-collection/${selectedHistoryItem.id}`, {
+                    method: 'DELETE'
+                });
+
+                if (response.ok) {
+                    closeModal();
+                    await loadMyCollection();
+                } else {
+                    const data = await response.json();
+                    alert('Failed to remove: ' + (data.error || 'Unknown error'));
+                }
+            } catch (error) {
+                console.error('Remove failed:', error);
+                alert('Failed to remove from collection');
+            }
         }
 
         function togglePreviewOrientation() {
@@ -1956,9 +2231,9 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
         }
 
         // Crop adjustment
-        let cropX = 50; // percentage
-        let cropY = 50; // percentage
-        const CROP_STEP = 5; // percentage step for each adjustment
+        let cropX = 50;
+        let cropY = 50;
+        const CROP_STEP = 5;
 
         function adjustCrop(direction) {
             const modalImage = document.getElementById('modalImage');
@@ -1986,7 +2261,7 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
         }
 
         // Zoom adjustment
-        let zoomLevel = 1.0; // 1.0 = fill (cover), < 1.0 = margins (contain)
+        let zoomLevel = 1.0;
         const ZOOM_STEP = 0.1;
 
         function adjustZoom(direction) {
@@ -2004,19 +2279,14 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
                     break;
             }
 
-            // Scale > 1.0 = zoom in (more crop)
-            // Scale < 1.0 = zoom out (show margins)
             modalImage.style.transform = `scale(${zoomLevel})`;
 
-            // When zoomed out (scale < 1), switch to contain to show margins
-            // When zoomed in (scale >= 1), use cover to crop
             if (zoomLevel < 1.0) {
                 modalImage.style.objectFit = 'contain';
             } else {
                 modalImage.style.objectFit = 'cover';
             }
         }
-
 
         // File upload
         function setupDragDrop() {
@@ -2050,7 +2320,6 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
         }
 
         async function handleFileUpload(file) {
-            // Show upload overlay
             const overlay = document.getElementById('generationOverlay');
             const statusText = document.getElementById('generationStatusText');
             const promptText = document.getElementById('generationPromptText');
@@ -2072,25 +2341,14 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
 
                 if (response.ok) {
                     const data = await response.json();
-
-                    // Clear file input
                     document.getElementById('fileInput').value = '';
-
-                    // Load the new current display
                     await loadCurrentDisplay();
-
-                    // Hide upload overlay
                     overlay.classList.remove('show');
-
-                    // Reset overlay text for next generation
                     statusText.textContent = 'Generating image...';
                     filenameText.textContent = '';
 
-                    // Open preview modal with the uploaded image
                     await openGeneratedImagePreview(data.imageId || 'current');
-
-                    // Reload history
-                    setTimeout(loadHistory, 1000);
+                    setTimeout(loadMyCollection, 1000);
                 } else {
                     overlay.classList.remove('show');
                     statusText.textContent = 'Generating image...';
@@ -2107,34 +2365,9 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
             }
         }
 
-        // History
-        let selectedHistoryItem = null;
-
-        async function loadHistory() {
-            try {
-                const response = await fetch('/api/history');
-                const history = await response.json();
-
-                const grid = document.getElementById('historyGrid');
-
-                if (history.length === 0) {
-                    grid.innerHTML = '';
-                    return;
-                }
-
-                grid.innerHTML = history.slice(0, 8).map(item => `
-                    <div class="history-item" onclick="openHistoryPreview('${item.imageId}')">
-                        <img class="history-image" src="data:image/png;base64,${item.thumbnail}" alt="">
-                    </div>
-                `).join('');
-            } catch (error) {
-                console.error('History load failed:', error);
-            }
-        }
-
+        // History (kept for generated/uploaded images)
         async function openHistoryPreview(imageId) {
             try {
-                // Fetch full image data from images.json endpoint
                 const response = await fetch(`/api/images/${imageId}`);
                 if (!response.ok) {
                     console.error('Image not found');
@@ -2144,20 +2377,13 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
                 const item = await response.json();
                 selectedHistoryItem = item;
 
-                // Set modal image - use originalImage for better quality preview
                 const imageSrc = item.originalImage
                     ? `data:${item.originalImageMime || 'image/png'};base64,${item.originalImage}`
                     : `data:image/png;base64,${item.thumbnail}`;
 
                 document.getElementById('modalImage').src = imageSrc;
-
-                // Apply default orientation
                 applyDefaultOrientation();
-
-                // Show delete button for history items
                 document.getElementById('deleteModalBtn').style.display = 'inline-block';
-
-                // Open modal
                 document.getElementById('artModal').classList.add('show');
             } catch (error) {
                 console.error('Failed to open preview:', error);
@@ -2169,21 +2395,17 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
 
             try {
                 let response;
-
-                // Get rotation from modal orientation
                 const modalImage = document.getElementById('modalImage');
                 const isLandscape = modalImage.classList.contains('landscape');
                 const rotation = isLandscape ? 90 : 0;
 
                 if (selectedHistoryItem) {
-                    // Load from history with rotation
                     response = await fetch(`/api/history/${selectedHistoryItem.imageId}/load`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ rotation })
                     });
                 } else if (selectedModalArt) {
-                    // Apply browse result with rotation
                     response = await fetch('/api/art/import', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
@@ -2208,7 +2430,7 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
         async function deleteModalImage() {
             if (!selectedHistoryItem) return;
 
-            if (!confirm('Are you sure you want to delete this image from history?')) {
+            if (!confirm('Are you sure you want to delete this image?')) {
                 return;
             }
 
@@ -2216,7 +2438,7 @@ console.log('[MockAPI] Preview mode activated - generating artistic placeholders
                 const response = await fetch(`/api/history/${selectedHistoryItem.imageId}`, { method: 'DELETE' });
                 if (response.ok) {
                     closeModal();
-                    loadHistory();
+                    await loadMyCollection();
                 } else {
                     const data = await response.json();
                     alert('Failed to delete: ' + (data.error || 'Unknown error'));

--- a/server/preview/mock-api.js
+++ b/server/preview/mock-api.js
@@ -714,6 +714,67 @@ class MockAPI {
             return { ip: '192.168.1.100' };
         }
 
+        if (path.startsWith('/api/stats') && method === 'GET') {
+            // Generate realistic mock statistics for preview
+            return {
+                openai: {
+                    summary: {
+                        totalCalls: 156,
+                        totalTokens: 45230,
+                        totalCost: 0.2847,
+                        byModel: {
+                            'gpt-image-1': {
+                                calls: 89,
+                                tokens: 0,  // Image generation doesn't use text tokens
+                                cost: 0.1780  // $0.002 per image * 89
+                            },
+                            'gpt-4o': {
+                                calls: 42,
+                                tokens: 28450,
+                                cost: 0.0712
+                            },
+                            'gpt-4o-mini': {
+                                calls: 25,
+                                tokens: 16780,
+                                cost: 0.0355
+                            }
+                        }
+                    }
+                },
+                apiCalls: {
+                    summary: {
+                        totalCalls: 324,
+                        bySource: {
+                            'Met Museum': {
+                                calls: 128,
+                                successes: 115
+                            },
+                            'Rijksmuseum': {
+                                calls: 87,
+                                successes: 79
+                            },
+                            'Art Institute Chicago': {
+                                calls: 64,
+                                successes: 58
+                            },
+                            'Harvard Art Museums': {
+                                calls: 45,
+                                successes: 38
+                            }
+                        }
+                    }
+                },
+                logs: {
+                    summary: {
+                        byLevel: {
+                            INFO: 1247,
+                            ERROR: 23
+                        }
+                    }
+                }
+            };
+        }
+
         return { error: 'Not found' };
     }
 }


### PR DESCRIPTION
Added detailed tracking and visualization for OpenAI API usage, museum API calls, and system logs in the admin dashboard.

Backend changes (server.js):
- Created statistics tracking module with persistent storage in stats.json
- Added OpenAI API call tracking with token counting and cost estimation
  - Tracks usage for gpt-image-1, gpt-4, gpt-4o-mini across all endpoints
  - Calculates costs based on 2025 pricing (input/output tokens)
- Added museum API tracking for all 8 art sources
  - Met Museum, ARTIC, Cleveland, Rijksmuseum, Wikimedia, V&A, Harvard, Smithsonian
  - Tracks success/failure rates for each source
- Integrated log tracking with console.log/error intercept
  - Tracks INFO and ERROR log counts
- Created API endpoints:
  - GET /api/stats?range={1h|24h|7d|all} - Retrieve statistics
  - POST /api/stats/reset - Reset all statistics

Frontend changes (admin.html):
- Added "API Usage Statistics" section with calm, minimal design
- OpenAI metrics display:
  - Total calls, tokens, estimated cost
  - Breakdown by model with usage bars and per-model costs
- Museum API metrics display:
  - Total calls and overall success rate
  - Per-source breakdown with call counts and success rates
  - Color-coded success indicators (green >80%, yellow >50%, red <50%)
- Log visualization:
  - Simple bar charts showing INFO vs ERROR log distribution
- Time range filters: 1 hour, 24 hours, 7 days, all time
- Auto-refresh capability

Design principles followed:
- Monochrome aesthetic (black, white, gray)
- Minimal, clean interface with subtle feedback
- Typography-driven design with proper spacing
- Progressive disclosure (stats collapsed by model/source)
- No decorative elements, focus on data